### PR TITLE
RepositoryListViewControllerのUISearchBarの命名をRename

### DIFF
--- a/iOSEngineerCodeCheck/Base.lproj/Main.storyboard
+++ b/iOSEngineerCodeCheck/Base.lproj/Main.storyboard
@@ -54,7 +54,7 @@
                     </tableView>
                     <navigationItem key="navigationItem" title="Root View Controller" id="ktq-eC-ZBq"/>
                     <connections>
-                        <outlet property="SchBr" destination="6rq-CD-Hob" id="3gq-mK-4M3"/>
+                        <outlet property="searchBar" destination="6rq-CD-Hob" id="mOM-jp-zYM"/>
                         <segue destination="AHY-RL-7mG" kind="show" identifier="Detail" id="qqd-8W-4W1"/>
                     </connections>
                 </tableViewController>

--- a/iOSEngineerCodeCheck/RepositoryListViewControllerViewController.swift
+++ b/iOSEngineerCodeCheck/RepositoryListViewControllerViewController.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 class RepositoryListViewController: UITableViewController, UISearchBarDelegate {
-    @IBOutlet weak var SchBr: UISearchBar!
+    @IBOutlet weak var searchBar: UISearchBar!
     
     var repositoryDataList: [[String: Any]] = []
     
@@ -22,8 +22,8 @@ class RepositoryListViewController: UITableViewController, UISearchBarDelegate {
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view.
-        SchBr.text = "GitHubのリポジトリを検索できるよー"
-        SchBr.delegate = self
+        searchBar.text = "GitHubのリポジトリを検索できるよー"
+        searchBar.delegate = self
     }
     
     func searchBarShouldBeginEditing(_ searchBar: UISearchBar) -> Bool {


### PR DESCRIPTION
## 概要
略す必要がないので略さないようRename

## issue
#1 