### PR TITLE
cell.detailTextLabelがnilになる不具合修正

### DIFF
--- a/iOSEngineerCodeCheck/RepositoryListViewControllerViewController.swift
+++ b/iOSEngineerCodeCheck/RepositoryListViewControllerViewController.swift
@@ -77,7 +77,7 @@ class RepositoryListViewController: UITableViewController, UISearchBarDelegate {
     }
     
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = UITableViewCell()
+        let cell = UITableViewCell(style: .subtitle, reuseIdentifier: "subtitleCell")
         let rp = repositoryDataList[indexPath.row]
         cell.textLabel?.text = rp["full_name"] as? String ?? ""
         cell.detailTextLabel?.text = rp["language"] as? String ?? ""


### PR DESCRIPTION
## 概要
cell.detailTextLabelがnilでlanguageが表示されなかった不具合を修正

## 作業内容
- UITableViewCellのstyleをsubtitleを指定して生成するように修正

## issue
#2
 
## UI
| Before | After |
| ------------- | ------------- |
| <img src="https://user-images.githubusercontent.com/20432404/201463367-9c522d0c-72e7-480c-9d4d-52d96fd95cb4.png" width=250 heigh=500>  | <img src="https://user-images.githubusercontent.com/20432404/201463363-6bf21663-e69c-4261-a1d8-21fb68add0ac.png" width=250 heigh=500>  |