### PR TITLE
各API呼び出しのクロージャのメモリリークを修正

### DIFF
--- a/iOSEngineerCodeCheck/RepositoryDetailViewController.swift
+++ b/iOSEngineerCodeCheck/RepositoryDetailViewController.swift
@@ -54,7 +54,8 @@ class RepositoryDetailViewController: UIViewController {
             return
         }
         
-        URLSession.shared.dataTask(with: imgURL) { data, _, _ in
+        URLSession.shared.dataTask(with: imgURL) { [weak self] data, _, _ in
+            guard let self = self else { return }
             guard let data = data,
                   let img = UIImage(data: data) else {
                 return

--- a/iOSEngineerCodeCheck/RepositoryListViewControllerViewController.swift
+++ b/iOSEngineerCodeCheck/RepositoryListViewControllerViewController.swift
@@ -45,7 +45,8 @@ class RepositoryListViewController: UITableViewController, UISearchBarDelegate {
         guard let apiURL = URL(string: "https://api.github.com/search/repositories?q=\(searchWord)") else {
             return
         }
-        task = URLSession.shared.dataTask(with: apiURL) { data, _, _ in
+        task = URLSession.shared.dataTask(with: apiURL) { [weak self] data, _, _ in
+            guard let self = self else { return }
             guard let data = data,
                   let obj = try! JSONSerialization.jsonObject(with: data) as? [String: Any] else {
                 return


### PR DESCRIPTION
## 概要
クロージャとselfが循環参照しているので修正を行った

## 作業内容
- クロージャでselfを使用している部分に[weak self]を使用するように修正

## issue
#3 