### PR TITLE
リポジトリ検索画面で検索結果のCellが押下できないバグを修正

### DIFF
--- a/iOSEngineerCodeCheck/UserInterface/RepositoryList/RepositoryListViewController.swift
+++ b/iOSEngineerCodeCheck/UserInterface/RepositoryList/RepositoryListViewController.swift
@@ -39,6 +39,7 @@ class RepositoryListViewController: UITableViewController, UISearchBarDelegate {
         searchBar.delegate = self
         tableView.dataSource = nil
         tableView.delegate = nil
+        tableView.keyboardDismissMode = .onDrag
         
         bind()
     }
@@ -75,17 +76,12 @@ class RepositoryListViewController: UITableViewController, UISearchBarDelegate {
             })
             .disposed(by: disposeBag)
         
-        view.rx.tapGesture()
-            .when(.recognized)
-            .bind(to: Binder(self) { me, _ in
-                me.view.endEditing(true)
+        view.rx.tapGesture(configuration: { rec, _ in
+                rec.cancelsTouchesInView = false
             })
-            .disposed(by: disposeBag)
-        
-        tableView.rx.swipeGesture([.up, .down])
             .when(.recognized)
             .bind(to: Binder(self) { me, _ in
-                me.view.endEditing(true)
+                me.tableView.endEditing(true)
             })
             .disposed(by: disposeBag)
     }


### PR DESCRIPTION
## 概要
SSIA

## issue
fix #83 

## 作業内容
- appleが提供している機能を使用した方がいいと思うのでtableViewのスクロールに関してはkeyboardDismissModeを使用するように修正
- view以外のtapイベントが配信されるようにcancelsTouchesInViewをfalseに設定