### PR TITLE
リポジトリ詳細画面のUIをブラッシュアップ

### DIFF
--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -60,6 +60,9 @@
 		15CD718A2928BF2700CF2A10 /* DependencyInjectable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15CD71892928BF2700CF2A10 /* DependencyInjectable.swift */; };
 		15CFE73729310DAA00A550A0 /* RepositoryDetailState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15CFE73629310DAA00A550A0 /* RepositoryDetailState.swift */; };
 		15CFE73A29333EDA00A550A0 /* RepositoryListStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15CFE73929333EDA00A550A0 /* RepositoryListStoreTests.swift */; };
+		15D04B8F2955FA1500B4511F /* CardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15D04B8E2955FA1500B4511F /* CardView.swift */; };
+		15D04B912956015B00B4511F /* BlurEffectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15D04B902956015B00B4511F /* BlurEffectView.swift */; };
+		15D04B94295604E000B4511F /* BlurEffectView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 15D04B93295604E000B4511F /* BlurEffectView.xib */; };
 		15E143C6291FA70500D980A3 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 15E143C5291FA70500D980A3 /* Kingfisher */; };
 		15E143CA291FF01A00D980A3 /* Requestable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15E143C9291FF01A00D980A3 /* Requestable.swift */; };
 		15E143CC291FF05900D980A3 /* Parameterizable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15E143CB291FF05900D980A3 /* Parameterizable.swift */; };
@@ -137,6 +140,9 @@
 		15CD71892928BF2700CF2A10 /* DependencyInjectable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DependencyInjectable.swift; sourceTree = "<group>"; };
 		15CFE73629310DAA00A550A0 /* RepositoryDetailState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryDetailState.swift; sourceTree = "<group>"; };
 		15CFE73929333EDA00A550A0 /* RepositoryListStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryListStoreTests.swift; sourceTree = "<group>"; };
+		15D04B8E2955FA1500B4511F /* CardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardView.swift; sourceTree = "<group>"; };
+		15D04B902956015B00B4511F /* BlurEffectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlurEffectView.swift; sourceTree = "<group>"; };
+		15D04B93295604E000B4511F /* BlurEffectView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = BlurEffectView.xib; sourceTree = "<group>"; };
 		15E143C9291FF01A00D980A3 /* Requestable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Requestable.swift; sourceTree = "<group>"; };
 		15E143CB291FF05900D980A3 /* Parameterizable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Parameterizable.swift; sourceTree = "<group>"; };
 		15E143D12920CD3400D980A3 /* APIClientError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientError.swift; sourceTree = "<group>"; };
@@ -260,8 +266,10 @@
 		15A457DD293B9D44002068F9 /* UIComponent */ = {
 			isa = PBXGroup;
 			children = (
+				15D04B92295604CA00B4511F /* BlurEffectView */,
 				15C677E82951E26E005BABCB /* RepositoryListCell */,
 				15A457DE293B9D76002068F9 /* LoadingView.swift */,
+				15D04B8E2955FA1500B4511F /* CardView.swift */,
 			);
 			path = UIComponent;
 			sourceTree = "<group>";
@@ -451,6 +459,15 @@
 				15A55302294DA0EE003448C3 /* RepositoryDetailStoreTests.swift */,
 			);
 			path = Store;
+			sourceTree = "<group>";
+		};
+		15D04B92295604CA00B4511F /* BlurEffectView */ = {
+			isa = PBXGroup;
+			children = (
+				15D04B902956015B00B4511F /* BlurEffectView.swift */,
+				15D04B93295604E000B4511F /* BlurEffectView.xib */,
+			);
+			path = BlurEffectView;
 			sourceTree = "<group>";
 		};
 		15E143C7291FE19D00D980A3 /* Repository */ = {
@@ -702,6 +719,7 @@
 				15C677EC2951E2BC005BABCB /* RepositoryListCell.xib in Resources */,
 				BFD945E8244DC5EB0012785A /* Assets.xcassets in Resources */,
 				BFD945E6244DC5E80012785A /* RepositoryList.storyboard in Resources */,
+				15D04B94295604E000B4511F /* BlurEffectView.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -792,6 +810,7 @@
 				15E143D22920CD3400D980A3 /* APIClientError.swift in Sources */,
 				15CD71852928A80D00CF2A10 /* Segues.swift in Sources */,
 				15E143D52920CFA700D980A3 /* SearchGitHubRepositoryParameter.swift in Sources */,
+				15D04B8F2955FA1500B4511F /* CardView.swift in Sources */,
 				159FA69F29449D1F00B92DAD /* FavoriteListViewController.swift in Sources */,
 				15E143CA291FF01A00D980A3 /* Requestable.swift in Sources */,
 				15CA110C292CF8D100941B76 /* Event.swift in Sources */,
@@ -804,6 +823,7 @@
 				15CA1117292DC41600941B76 /* AnyRequest.swift in Sources */,
 				15E143DC2920E78D00D980A3 /* Owner.swift in Sources */,
 				BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */,
+				15D04B912956015B00B4511F /* BlurEffectView.swift in Sources */,
 				15A457DF293B9D76002068F9 /* LoadingView.swift in Sources */,
 				BFD945E1244DC5E80012785A /* SceneDelegate.swift in Sources */,
 				15C677EB2951E2BC005BABCB /* RepositoryListCell.swift in Sources */,

--- a/iOSEngineerCodeCheck/SceneDelegate.swift
+++ b/iOSEngineerCodeCheck/SceneDelegate.swift
@@ -10,6 +10,7 @@ import UIKit
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     var window: UIWindow?
+    static var statusBarHeight: CGFloat = 0
     private var coordinator: ApplicationCoordinator!
     
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
@@ -20,6 +21,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window = UIWindow(windowScene: scene)
         coordinator = ApplicationCoordinator()
         coordinator.start(with: window!)
+        SceneDelegate.statusBarHeight = window?.windowScene?.statusBarManager?.statusBarFrame.height ?? 0
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {

--- a/iOSEngineerCodeCheck/UIComponent/BlurEffectView/BlurEffectView.swift
+++ b/iOSEngineerCodeCheck/UIComponent/BlurEffectView/BlurEffectView.swift
@@ -1,0 +1,44 @@
+//
+//  BlurEffectView.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by 杉岡成哉 on 2022/12/24.
+//  Copyright © 2022 YUMEMI Inc. All rights reserved.
+//
+
+import UIKit
+
+class BlurEffectView: UIView {
+    
+    @IBOutlet weak var image: UIImageView!
+    
+    private var blurEffectView: UIVisualEffectView?
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        nibInit()
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        nibInit()
+    }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        blurEffectView?.frame = self.frame
+    }
+
+    private func nibInit() {
+        let nib = UINib(nibName: "BlurEffectView", bundle: nil)
+        guard let view = nib.instantiate(withOwner: self, options: nil).first as? UIView else { return }
+        addSubview(view)
+        
+        let blurEffect = UIBlurEffect(style: .regular)
+        blurEffectView = UIVisualEffectView(effect: blurEffect)
+        guard let blurEffectView = blurEffectView else {
+            return
+        }
+        addSubview(blurEffectView)
+    }
+}

--- a/iOSEngineerCodeCheck/UIComponent/BlurEffectView/BlurEffectView.swift
+++ b/iOSEngineerCodeCheck/UIComponent/BlurEffectView/BlurEffectView.swift
@@ -34,7 +34,7 @@ class BlurEffectView: UIView {
         guard let view = nib.instantiate(withOwner: self, options: nil).first as? UIView else { return }
         addSubview(view)
         
-        let blurEffect = UIBlurEffect(style: .regular)
+        let blurEffect = UIBlurEffect(style: .systemMaterial)
         blurEffectView = UIVisualEffectView(effect: blurEffect)
         guard let blurEffectView = blurEffectView else {
             return

--- a/iOSEngineerCodeCheck/UIComponent/BlurEffectView/BlurEffectView.swift
+++ b/iOSEngineerCodeCheck/UIComponent/BlurEffectView/BlurEffectView.swift
@@ -23,11 +23,6 @@ class BlurEffectView: UIView {
         super.init(coder: aDecoder)
         nibInit()
     }
-    
-    override func layoutSubviews() {
-        super.layoutSubviews()
-        blurEffectView?.frame = self.frame
-    }
 
     private func nibInit() {
         let nib = UINib(nibName: "BlurEffectView", bundle: nil)
@@ -36,9 +31,14 @@ class BlurEffectView: UIView {
         
         let blurEffect = UIBlurEffect(style: .systemMaterial)
         blurEffectView = UIVisualEffectView(effect: blurEffect)
+        blurEffectView?.translatesAutoresizingMaskIntoConstraints = false
         guard let blurEffectView = blurEffectView else {
             return
         }
         addSubview(blurEffectView)
+        blurEffectView.topAnchor.constraint(equalTo: self.topAnchor, constant: 0).isActive = true
+        blurEffectView.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: 0).isActive = true
+        blurEffectView.rightAnchor.constraint(equalTo: self.rightAnchor, constant: 0).isActive = true
+        blurEffectView.leftAnchor.constraint(equalTo: self.leftAnchor, constant: 0).isActive = true
     }
 }

--- a/iOSEngineerCodeCheck/UIComponent/BlurEffectView/BlurEffectView.xib
+++ b/iOSEngineerCodeCheck/UIComponent/BlurEffectView/BlurEffectView.xib
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="BlurEffectView" customModule="iOSEngineerCodeCheck" customModuleProvider="target">
+            <connections>
+                <outlet property="image" destination="u2a-Ut-LvT" id="1yK-WC-4DJ"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="303"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="u2a-Ut-LvT">
+                    <rect key="frame" x="0.0" y="0.0" width="414" height="212"/>
+                </imageView>
+            </subviews>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
+            <color key="backgroundColor" systemColor="systemGroupedBackgroundColor"/>
+            <constraints>
+                <constraint firstItem="u2a-Ut-LvT" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="3VA-eJ-aO0"/>
+                <constraint firstItem="u2a-Ut-LvT" firstAttribute="height" secondItem="iN0-l3-epB" secondAttribute="height" multiplier="0.7" id="dQk-rH-6Cm"/>
+                <constraint firstItem="u2a-Ut-LvT" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="deE-oZ-Nv9"/>
+                <constraint firstAttribute="trailing" secondItem="u2a-Ut-LvT" secondAttribute="trailing" id="fSC-eb-zWo"/>
+            </constraints>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <point key="canvasLocation" x="131.8840579710145" y="-122.87946428571428"/>
+        </view>
+    </objects>
+    <resources>
+        <systemColor name="systemGroupedBackgroundColor">
+            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+    </resources>
+</document>

--- a/iOSEngineerCodeCheck/UIComponent/CardView.swift
+++ b/iOSEngineerCodeCheck/UIComponent/CardView.swift
@@ -10,11 +10,11 @@ import UIKit
 
 @IBDesignable
 class CardView: UIView {
-    @IBInspectable var cornerRadius: CGFloat = 2
+    @IBInspectable var cornerRadius: CGFloat = 10
     @IBInspectable var shadowOffsetWidth: Int = 0
-    @IBInspectable var shadowOffsetHeight: Int = 3
+    @IBInspectable var shadowOffsetHeight: Int = 1
     @IBInspectable var shadowColor: UIColor? = .black
-    @IBInspectable var shadowOpacity: Float = 0.5
+    @IBInspectable var shadowOpacity: Float = 0.3
     
     override func layoutSubviews() {
         layer.cornerRadius = cornerRadius

--- a/iOSEngineerCodeCheck/UIComponent/CardView.swift
+++ b/iOSEngineerCodeCheck/UIComponent/CardView.swift
@@ -1,0 +1,29 @@
+//
+//  CardView.swift
+//  iOSEngineerCodeCheck
+//
+//  Created by 杉岡成哉 on 2022/12/24.
+//  Copyright © 2022 YUMEMI Inc. All rights reserved.
+//
+
+import UIKit
+
+@IBDesignable
+class CardView: UIView {
+    @IBInspectable var cornerRadius: CGFloat = 2
+    @IBInspectable var shadowOffsetWidth: Int = 0
+    @IBInspectable var shadowOffsetHeight: Int = 3
+    @IBInspectable var shadowColor: UIColor? = .black
+    @IBInspectable var shadowOpacity: Float = 0.5
+    
+    override func layoutSubviews() {
+        layer.cornerRadius = cornerRadius
+        let shadowPath = UIBezierPath(roundedRect: bounds, cornerRadius: cornerRadius)
+
+        layer.masksToBounds = false
+        layer.shadowColor = shadowColor?.cgColor
+        layer.shadowOffset = CGSize(width: shadowOffsetWidth, height: shadowOffsetHeight)
+        layer.shadowOpacity = shadowOpacity
+        layer.shadowPath = shadowPath.cgPath
+    }
+}

--- a/iOSEngineerCodeCheck/UserInterface/RepositoryDetail/RepositoryDetail.storyboard
+++ b/iOSEngineerCodeCheck/UserInterface/RepositoryDetail/RepositoryDetail.storyboard
@@ -23,11 +23,11 @@
                                         <rect key="frame" x="0.0" y="0.0" width="414" height="650"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="FW9-Jg-tmn" customClass="BlurEffectView" customModule="iOSEngineerCodeCheck" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="-100" width="414" height="423"/>
+                                                <rect key="frame" x="0.0" y="-100" width="414" height="467"/>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2zO-KN-Vw8" customClass="CardView" customModule="iOSEngineerCodeCheck" customModuleProvider="target">
-                                                <rect key="frame" x="107" y="0.0" width="200" height="200"/>
+                                                <rect key="frame" x="107" y="44" width="200" height="200"/>
                                                 <subviews>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="a0m-Bh-z32">
                                                         <rect key="frame" x="0.0" y="0.0" width="200" height="200"/>
@@ -45,7 +45,7 @@
                                                 </constraints>
                                             </view>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qER-dV-dCF">
-                                                <rect key="frame" x="16" y="220" width="382" height="35"/>
+                                                <rect key="frame" x="16" y="264" width="382" height="35"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="TitleLabel"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="35" id="4c0-iz-mSz"/>
@@ -55,7 +55,7 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qUk-nT-bqJ">
-                                                <rect key="frame" x="16" y="263" width="382" height="20"/>
+                                                <rect key="frame" x="16" y="307" width="382" height="20"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="20" id="dMh-Tn-ywC"/>
                                                 </constraints>
@@ -64,7 +64,7 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="ZPx-bY-Rgt">
-                                                <rect key="frame" x="16" y="343" width="382" height="164"/>
+                                                <rect key="frame" x="16" y="387" width="382" height="164"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="MHs-eQ-CAq">
                                                         <rect key="frame" x="0.0" y="0.0" width="382" height="164"/>
@@ -171,7 +171,7 @@
                                             <constraint firstItem="qER-dV-dCF" firstAttribute="top" secondItem="2zO-KN-Vw8" secondAttribute="bottom" constant="20" id="BIT-Ck-25S"/>
                                             <constraint firstItem="qUk-nT-bqJ" firstAttribute="leading" secondItem="UCT-cv-sfg" secondAttribute="leading" constant="16" id="GZl-Ks-b3H"/>
                                             <constraint firstItem="FW9-Jg-tmn" firstAttribute="top" secondItem="UCT-cv-sfg" secondAttribute="top" constant="-100" id="LwX-Av-qaA"/>
-                                            <constraint firstItem="2zO-KN-Vw8" firstAttribute="top" secondItem="UCT-cv-sfg" secondAttribute="top" id="TVy-XP-4bG"/>
+                                            <constraint firstItem="2zO-KN-Vw8" firstAttribute="top" secondItem="UCT-cv-sfg" secondAttribute="top" constant="44" id="TVy-XP-4bG"/>
                                             <constraint firstItem="qUk-nT-bqJ" firstAttribute="bottom" secondItem="FW9-Jg-tmn" secondAttribute="bottom" constant="-40" id="U5M-Lt-Pc2"/>
                                             <constraint firstItem="2zO-KN-Vw8" firstAttribute="centerX" secondItem="UCT-cv-sfg" secondAttribute="centerX" id="dUF-nm-krq"/>
                                             <constraint firstItem="qER-dV-dCF" firstAttribute="leading" secondItem="UCT-cv-sfg" secondAttribute="leading" constant="16" id="eXM-I6-glu"/>

--- a/iOSEngineerCodeCheck/UserInterface/RepositoryDetail/RepositoryDetail.storyboard
+++ b/iOSEngineerCodeCheck/UserInterface/RepositoryDetail/RepositoryDetail.storyboard
@@ -17,7 +17,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="iGU-ar-QBa" customClass="BlurEffectView" customModule="iOSEngineerCodeCheck" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="0.0" width="414" height="393"/>
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="363"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="FA5-zu-hgT" customClass="CardView" customModule="iOSEngineerCodeCheck" customModuleProvider="target">
@@ -49,16 +49,16 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wfy-1Y-jlW">
-                                <rect key="frame" x="16" y="327" width="382" height="50"/>
+                                <rect key="frame" x="16" y="327" width="382" height="20"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="50" id="h8H-uD-ssP"/>
+                                    <constraint firstAttribute="height" constant="20" id="YyU-iA-Tce"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="CME-ZA-M8T">
-                                <rect key="frame" x="16" y="433" width="382" height="106"/>
+                                <rect key="frame" x="16" y="403" width="382" height="106"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Language" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ebJ-x4-Gpg">
                                         <rect key="frame" x="0.0" y="0.0" width="66.5" height="17"/>

--- a/iOSEngineerCodeCheck/UserInterface/RepositoryDetail/RepositoryDetail.storyboard
+++ b/iOSEngineerCodeCheck/UserInterface/RepositoryDetail/RepositoryDetail.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="pAq-kQ-gQs">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="aWD-Gk-ckJ">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
@@ -9,189 +9,218 @@
     </dependencies>
     <scenes>
         <!--Repository Detail View Controller-->
-        <scene sceneID="PJ5-IM-gfa">
+        <scene sceneID="6G7-JO-ug7">
             <objects>
-                <viewController id="pAq-kQ-gQs" customClass="RepositoryDetailViewController" customModule="iOSEngineerCodeCheck" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="wCv-FG-8ah">
+                <viewController id="aWD-Gk-ckJ" customClass="RepositoryDetailViewController" customModule="iOSEngineerCodeCheck" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="r8g-wx-lKz">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="iGU-ar-QBa" customClass="BlurEffectView" customModule="iOSEngineerCodeCheck" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="0.0" width="414" height="367"/>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                            </view>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="FA5-zu-hgT" customClass="CardView" customModule="iOSEngineerCodeCheck" customModuleProvider="target">
-                                <rect key="frame" x="107" y="44" width="200" height="200"/>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" contentInsetAdjustmentBehavior="never" translatesAutoresizingMaskIntoConstraints="NO" id="XQ1-Ly-eNg">
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="862"/>
                                 <subviews>
-                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Utg-8F-B0A">
-                                        <rect key="frame" x="0.0" y="0.0" width="200" height="200"/>
-                                        <accessibility key="accessibilityConfiguration" identifier="AvatarImage"/>
-                                    </imageView>
-                                </subviews>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                <constraints>
-                                    <constraint firstItem="Utg-8F-B0A" firstAttribute="top" secondItem="FA5-zu-hgT" secondAttribute="top" id="90c-kM-b3e"/>
-                                    <constraint firstAttribute="trailing" secondItem="Utg-8F-B0A" secondAttribute="trailing" id="OkK-Ue-EoZ"/>
-                                    <constraint firstAttribute="bottom" secondItem="Utg-8F-B0A" secondAttribute="bottom" id="RGj-fO-EfI"/>
-                                    <constraint firstAttribute="width" constant="200" id="mWD-Hb-hS4"/>
-                                    <constraint firstAttribute="height" constant="200" id="rdT-WT-wIk"/>
-                                    <constraint firstItem="Utg-8F-B0A" firstAttribute="leading" secondItem="FA5-zu-hgT" secondAttribute="leading" id="w4p-fR-fb5"/>
-                                </constraints>
-                            </view>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KsP-ju-rTn">
-                                <rect key="frame" x="16" y="264" width="382" height="35"/>
-                                <accessibility key="accessibilityConfiguration" identifier="TitleLabel"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="35" id="8SF-9z-gNR"/>
-                                </constraints>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
-                                <color key="textColor" systemColor="darkTextColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wfy-1Y-jlW">
-                                <rect key="frame" x="16" y="307" width="382" height="20"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="20" id="YyU-iA-Tce"/>
-                                </constraints>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="CME-ZA-M8T">
-                                <rect key="frame" x="16" y="407" width="382" height="161"/>
-                                <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="aVB-8r-8BG">
-                                        <rect key="frame" x="0.0" y="0.0" width="382" height="161"/>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="UCT-cv-sfg">
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="650"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Language" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ebJ-x4-Gpg">
-                                                <rect key="frame" x="0.0" y="0.0" width="382" height="17"/>
-                                                <accessibility key="accessibilityConfiguration" identifier="LanguageLabel"/>
-                                                <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="FW9-Jg-tmn" customClass="BlurEffectView" customModule="iOSEngineerCodeCheck" customModuleProvider="target">
+                                                <rect key="frame" x="0.0" y="-100" width="414" height="423"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                            </view>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2zO-KN-Vw8" customClass="CardView" customModule="iOSEngineerCodeCheck" customModuleProvider="target">
+                                                <rect key="frame" x="107" y="0.0" width="200" height="200"/>
+                                                <subviews>
+                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="a0m-Bh-z32">
+                                                        <rect key="frame" x="0.0" y="0.0" width="200" height="200"/>
+                                                        <accessibility key="accessibilityConfiguration" identifier="AvatarImage"/>
+                                                    </imageView>
+                                                </subviews>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                <constraints>
+                                                    <constraint firstItem="a0m-Bh-z32" firstAttribute="leading" secondItem="2zO-KN-Vw8" secondAttribute="leading" id="Jsv-Uh-rHe"/>
+                                                    <constraint firstAttribute="height" constant="200" id="QKl-dL-sh3"/>
+                                                    <constraint firstAttribute="bottom" secondItem="a0m-Bh-z32" secondAttribute="bottom" id="ZV3-jS-rf1"/>
+                                                    <constraint firstItem="a0m-Bh-z32" firstAttribute="top" secondItem="2zO-KN-Vw8" secondAttribute="top" id="brr-p2-2pa"/>
+                                                    <constraint firstAttribute="trailing" secondItem="a0m-Bh-z32" secondAttribute="trailing" id="fgd-Z3-wk0"/>
+                                                    <constraint firstAttribute="width" constant="200" id="xQV-z0-CRP"/>
+                                                </constraints>
+                                            </view>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qER-dV-dCF">
+                                                <rect key="frame" x="16" y="220" width="382" height="35"/>
+                                                <accessibility key="accessibilityConfiguration" identifier="TitleLabel"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="35" id="4c0-iz-mSz"/>
+                                                </constraints>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                                 <color key="textColor" systemColor="darkTextColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="ncj-Fg-HA8">
-                                                <rect key="frame" x="0.0" y="33" width="382" height="20"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qUk-nT-bqJ">
+                                                <rect key="frame" x="16" y="263" width="382" height="20"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="20" id="dMh-Tn-ywC"/>
+                                                </constraints>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="ZPx-bY-Rgt">
+                                                <rect key="frame" x="16" y="343" width="382" height="164"/>
                                                 <subviews>
-                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="star" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="u4J-MH-5Kf">
-                                                        <rect key="frame" x="0.0" y="-0.5" width="20" height="20"/>
-                                                        <color key="tintColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="width" constant="20" id="V3j-Q3-6pX"/>
-                                                            <constraint firstAttribute="height" constant="20" id="Zrv-tb-gAD"/>
-                                                        </constraints>
-                                                    </imageView>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Stars" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WQI-E4-rFR">
-                                                        <rect key="frame" x="24" y="0.0" width="358" height="20"/>
-                                                        <accessibility key="accessibilityConfiguration" identifier="StargazersCountLabel"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                                                        <color key="textColor" systemColor="darkTextColor"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                </subviews>
-                                            </stackView>
-                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="Hdr-r5-E5I">
-                                                <rect key="frame" x="0.0" y="69" width="382" height="20"/>
-                                                <subviews>
-                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="eye" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="ZvB-ui-5yG">
-                                                        <rect key="frame" x="0.0" y="1.5" width="20" height="16.5"/>
-                                                        <color key="tintColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="height" constant="20" id="LVa-Xl-Ill"/>
-                                                            <constraint firstAttribute="width" constant="20" id="e4S-yV-Bon"/>
-                                                        </constraints>
-                                                    </imageView>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Wathcers" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qF1-59-DTt">
-                                                        <rect key="frame" x="24" y="0.0" width="358" height="20"/>
-                                                        <accessibility key="accessibilityConfiguration" identifier="WachersCountLabel"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                                                        <color key="textColor" systemColor="darkTextColor"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                </subviews>
-                                            </stackView>
-                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="hie-Kj-2A0">
-                                                <rect key="frame" x="0.0" y="105" width="382" height="20"/>
-                                                <subviews>
-                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="point.topleft.down.curvedto.point.bottomright.up" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="Xe1-B7-Wqk">
-                                                        <rect key="frame" x="0.0" y="0.0" width="20" height="20"/>
-                                                        <color key="tintColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="width" constant="20" id="7TN-4L-f47"/>
-                                                            <constraint firstAttribute="height" constant="20" id="Vnw-Pj-EAJ"/>
-                                                        </constraints>
-                                                    </imageView>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Forks" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="V5a-Kr-PTT">
-                                                        <rect key="frame" x="24" y="0.0" width="358" height="20"/>
-                                                        <accessibility key="accessibilityConfiguration" identifier="ForksCountLabel"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                                                        <color key="textColor" systemColor="darkTextColor"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                </subviews>
-                                            </stackView>
-                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="YwG-gV-MuV">
-                                                <rect key="frame" x="0.0" y="141" width="382" height="20"/>
-                                                <subviews>
-                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="smallcircle.filled.circle" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="v4S-3I-Nww">
-                                                        <rect key="frame" x="0.0" y="0.5" width="20" height="19"/>
-                                                        <color key="tintColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="height" constant="20" id="GWX-Zl-8rz"/>
-                                                            <constraint firstAttribute="width" constant="20" id="hCw-rn-RTm"/>
-                                                        </constraints>
-                                                    </imageView>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Issues" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3Xu-zY-64o">
-                                                        <rect key="frame" x="24" y="0.0" width="358" height="20"/>
-                                                        <accessibility key="accessibilityConfiguration" identifier="OpenIssuesCountLabel"/>
-                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                                                        <color key="textColor" systemColor="darkTextColor"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="MHs-eQ-CAq">
+                                                        <rect key="frame" x="0.0" y="0.0" width="382" height="164"/>
+                                                        <subviews>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Language" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="m5r-09-aIc">
+                                                                <rect key="frame" x="0.0" y="0.0" width="382" height="20"/>
+                                                                <accessibility key="accessibilityConfiguration" identifier="LanguageLabel"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="height" constant="20" id="Xej-Ep-23R"/>
+                                                                </constraints>
+                                                                <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                                                                <color key="textColor" systemColor="darkTextColor"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="ba3-Ye-azF">
+                                                                <rect key="frame" x="0.0" y="36" width="382" height="20"/>
+                                                                <subviews>
+                                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="star" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="KrV-EW-oxi">
+                                                                        <rect key="frame" x="0.0" y="-0.5" width="20" height="20"/>
+                                                                        <color key="tintColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                        <constraints>
+                                                                            <constraint firstAttribute="height" constant="20" id="J1g-ph-idj"/>
+                                                                            <constraint firstAttribute="width" constant="20" id="gCD-N3-7h4"/>
+                                                                        </constraints>
+                                                                    </imageView>
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Stars" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bLp-4k-rV1">
+                                                                        <rect key="frame" x="24" y="0.0" width="358" height="20"/>
+                                                                        <accessibility key="accessibilityConfiguration" identifier="StargazersCountLabel"/>
+                                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                                                        <color key="textColor" systemColor="darkTextColor"/>
+                                                                        <nil key="highlightedColor"/>
+                                                                    </label>
+                                                                </subviews>
+                                                            </stackView>
+                                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="gpA-Ou-N3d">
+                                                                <rect key="frame" x="0.0" y="72" width="382" height="20"/>
+                                                                <subviews>
+                                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="eye" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="zW8-V7-i53">
+                                                                        <rect key="frame" x="0.0" y="1.5" width="20" height="16.5"/>
+                                                                        <color key="tintColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                        <constraints>
+                                                                            <constraint firstAttribute="width" constant="20" id="dzY-ww-qpe"/>
+                                                                            <constraint firstAttribute="height" constant="20" id="m7V-rr-G4e"/>
+                                                                        </constraints>
+                                                                    </imageView>
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Wathcers" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="erk-jg-HYt">
+                                                                        <rect key="frame" x="24" y="0.0" width="358" height="20"/>
+                                                                        <accessibility key="accessibilityConfiguration" identifier="WachersCountLabel"/>
+                                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                                                        <color key="textColor" systemColor="darkTextColor"/>
+                                                                        <nil key="highlightedColor"/>
+                                                                    </label>
+                                                                </subviews>
+                                                            </stackView>
+                                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="emo-88-dI2">
+                                                                <rect key="frame" x="0.0" y="108" width="382" height="20"/>
+                                                                <subviews>
+                                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="point.topleft.down.curvedto.point.bottomright.up" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="kdc-Y9-xli">
+                                                                        <rect key="frame" x="0.0" y="0.0" width="20" height="20"/>
+                                                                        <color key="tintColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                        <constraints>
+                                                                            <constraint firstAttribute="height" constant="20" id="Wuc-If-mOg"/>
+                                                                            <constraint firstAttribute="width" constant="20" id="nFU-bC-NGi"/>
+                                                                        </constraints>
+                                                                    </imageView>
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Forks" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Wkn-pu-8Uc">
+                                                                        <rect key="frame" x="24" y="0.0" width="358" height="20"/>
+                                                                        <accessibility key="accessibilityConfiguration" identifier="ForksCountLabel"/>
+                                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                                                        <color key="textColor" systemColor="darkTextColor"/>
+                                                                        <nil key="highlightedColor"/>
+                                                                    </label>
+                                                                </subviews>
+                                                            </stackView>
+                                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="zNi-KU-b6g">
+                                                                <rect key="frame" x="0.0" y="144" width="382" height="20"/>
+                                                                <subviews>
+                                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="smallcircle.filled.circle" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="KbJ-bd-166">
+                                                                        <rect key="frame" x="0.0" y="0.5" width="20" height="19"/>
+                                                                        <color key="tintColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                        <constraints>
+                                                                            <constraint firstAttribute="height" constant="20" id="0KQ-dT-Om3"/>
+                                                                            <constraint firstAttribute="width" constant="20" id="gMe-IW-sfn"/>
+                                                                        </constraints>
+                                                                    </imageView>
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Issues" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UkU-LY-9Ht">
+                                                                        <rect key="frame" x="24" y="0.0" width="358" height="20"/>
+                                                                        <accessibility key="accessibilityConfiguration" identifier="OpenIssuesCountLabel"/>
+                                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                                                        <color key="textColor" systemColor="darkTextColor"/>
+                                                                        <nil key="highlightedColor"/>
+                                                                    </label>
+                                                                </subviews>
+                                                            </stackView>
+                                                        </subviews>
+                                                    </stackView>
                                                 </subviews>
                                             </stackView>
                                         </subviews>
-                                    </stackView>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <constraints>
+                                            <constraint firstAttribute="trailing" secondItem="qUk-nT-bqJ" secondAttribute="trailing" constant="16" id="1mT-cw-RoQ"/>
+                                            <constraint firstAttribute="trailing" secondItem="FW9-Jg-tmn" secondAttribute="trailing" id="6gV-qy-25b"/>
+                                            <constraint firstItem="qER-dV-dCF" firstAttribute="top" secondItem="2zO-KN-Vw8" secondAttribute="bottom" constant="20" id="BIT-Ck-25S"/>
+                                            <constraint firstItem="qUk-nT-bqJ" firstAttribute="leading" secondItem="UCT-cv-sfg" secondAttribute="leading" constant="16" id="GZl-Ks-b3H"/>
+                                            <constraint firstItem="FW9-Jg-tmn" firstAttribute="top" secondItem="UCT-cv-sfg" secondAttribute="top" constant="-100" id="LwX-Av-qaA"/>
+                                            <constraint firstItem="2zO-KN-Vw8" firstAttribute="top" secondItem="UCT-cv-sfg" secondAttribute="top" id="TVy-XP-4bG"/>
+                                            <constraint firstItem="qUk-nT-bqJ" firstAttribute="bottom" secondItem="FW9-Jg-tmn" secondAttribute="bottom" constant="-40" id="U5M-Lt-Pc2"/>
+                                            <constraint firstItem="2zO-KN-Vw8" firstAttribute="centerX" secondItem="UCT-cv-sfg" secondAttribute="centerX" id="dUF-nm-krq"/>
+                                            <constraint firstItem="qER-dV-dCF" firstAttribute="leading" secondItem="UCT-cv-sfg" secondAttribute="leading" constant="16" id="eXM-I6-glu"/>
+                                            <constraint firstAttribute="trailing" secondItem="qER-dV-dCF" secondAttribute="trailing" constant="16" id="h3g-As-XLg"/>
+                                            <constraint firstItem="FW9-Jg-tmn" firstAttribute="leading" secondItem="UCT-cv-sfg" secondAttribute="leading" id="hgq-Ky-ufj"/>
+                                            <constraint firstItem="ZPx-bY-Rgt" firstAttribute="top" secondItem="FW9-Jg-tmn" secondAttribute="bottom" constant="20" id="kzt-pN-Qve"/>
+                                            <constraint firstItem="qUk-nT-bqJ" firstAttribute="top" secondItem="qER-dV-dCF" secondAttribute="bottom" constant="8" id="oCG-I8-AbX"/>
+                                            <constraint firstAttribute="height" constant="650" id="r8w-L3-crB"/>
+                                            <constraint firstItem="ZPx-bY-Rgt" firstAttribute="leading" secondItem="UCT-cv-sfg" secondAttribute="leading" constant="16" id="xXJ-tx-0na"/>
+                                            <constraint firstAttribute="trailing" secondItem="ZPx-bY-Rgt" secondAttribute="trailing" constant="16" id="yfo-xg-UoC"/>
+                                        </constraints>
+                                    </view>
                                 </subviews>
-                            </stackView>
+                                <constraints>
+                                    <constraint firstItem="UCT-cv-sfg" firstAttribute="width" secondItem="00E-A4-Fwr" secondAttribute="width" id="MsI-bO-tum"/>
+                                    <constraint firstItem="UCT-cv-sfg" firstAttribute="trailing" secondItem="KPS-PU-isI" secondAttribute="trailing" id="i7d-u7-aWd"/>
+                                    <constraint firstItem="UCT-cv-sfg" firstAttribute="bottom" secondItem="KPS-PU-isI" secondAttribute="bottom" id="iDc-TC-5Mf"/>
+                                    <constraint firstItem="UCT-cv-sfg" firstAttribute="top" secondItem="KPS-PU-isI" secondAttribute="top" id="llf-RE-I11"/>
+                                    <constraint firstItem="UCT-cv-sfg" firstAttribute="leading" secondItem="KPS-PU-isI" secondAttribute="leading" id="u7R-5j-ce7"/>
+                                </constraints>
+                                <viewLayoutGuide key="contentLayoutGuide" id="KPS-PU-isI"/>
+                                <viewLayoutGuide key="frameLayoutGuide" id="00E-A4-Fwr"/>
+                            </scrollView>
                         </subviews>
-                        <viewLayoutGuide key="safeArea" id="d8v-Sh-p7w"/>
+                        <viewLayoutGuide key="safeArea" id="VSd-2u-98q"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="d8v-Sh-p7w" firstAttribute="trailing" secondItem="KsP-ju-rTn" secondAttribute="trailing" constant="16" id="0Q9-cw-2T3"/>
-                            <constraint firstItem="CME-ZA-M8T" firstAttribute="leading" secondItem="d8v-Sh-p7w" secondAttribute="leading" constant="16" id="2m8-sT-YcO"/>
-                            <constraint firstItem="d8v-Sh-p7w" firstAttribute="trailing" secondItem="CME-ZA-M8T" secondAttribute="trailing" constant="16" id="30I-3X-d8k"/>
-                            <constraint firstItem="wfy-1Y-jlW" firstAttribute="centerX" secondItem="wCv-FG-8ah" secondAttribute="centerX" id="5nR-6i-ro8"/>
-                            <constraint firstItem="wfy-1Y-jlW" firstAttribute="leading" secondItem="d8v-Sh-p7w" secondAttribute="leading" constant="16" id="EGF-GM-wg9"/>
-                            <constraint firstItem="d8v-Sh-p7w" firstAttribute="trailing" secondItem="wfy-1Y-jlW" secondAttribute="trailing" constant="16" id="QY7-YA-cMs"/>
-                            <constraint firstItem="KsP-ju-rTn" firstAttribute="leading" secondItem="d8v-Sh-p7w" secondAttribute="leading" constant="16" id="Xoh-z5-jmV"/>
-                            <constraint firstItem="FA5-zu-hgT" firstAttribute="top" secondItem="d8v-Sh-p7w" secondAttribute="top" id="aom-9D-52Z"/>
-                            <constraint firstItem="d8v-Sh-p7w" firstAttribute="trailing" secondItem="iGU-ar-QBa" secondAttribute="trailing" id="eEz-6K-alp"/>
-                            <constraint firstItem="wfy-1Y-jlW" firstAttribute="bottom" secondItem="iGU-ar-QBa" secondAttribute="bottom" constant="-40" id="hKF-vy-2vT"/>
-                            <constraint firstItem="wfy-1Y-jlW" firstAttribute="top" secondItem="KsP-ju-rTn" secondAttribute="bottom" constant="8" id="kJE-5X-mYu"/>
-                            <constraint firstItem="CME-ZA-M8T" firstAttribute="top" secondItem="iGU-ar-QBa" secondAttribute="bottom" constant="40" id="m7M-LG-G9F"/>
-                            <constraint firstItem="FA5-zu-hgT" firstAttribute="centerX" secondItem="wCv-FG-8ah" secondAttribute="centerX" id="p9K-1I-CGC"/>
-                            <constraint firstItem="iGU-ar-QBa" firstAttribute="top" secondItem="wCv-FG-8ah" secondAttribute="top" id="qik-cg-fvU"/>
-                            <constraint firstItem="iGU-ar-QBa" firstAttribute="leading" secondItem="d8v-Sh-p7w" secondAttribute="leading" id="sZK-9R-OFF"/>
-                            <constraint firstItem="KsP-ju-rTn" firstAttribute="top" secondItem="FA5-zu-hgT" secondAttribute="bottom" constant="20" id="xZR-49-AZg"/>
+                            <constraint firstItem="XQ1-Ly-eNg" firstAttribute="trailing" secondItem="VSd-2u-98q" secondAttribute="trailing" id="2ee-jz-Zhk"/>
+                            <constraint firstItem="XQ1-Ly-eNg" firstAttribute="bottom" secondItem="VSd-2u-98q" secondAttribute="bottom" id="4pA-Tc-ZKR"/>
+                            <constraint firstItem="XQ1-Ly-eNg" firstAttribute="leading" secondItem="VSd-2u-98q" secondAttribute="leading" id="gcd-CW-IGy"/>
+                            <constraint firstItem="XQ1-Ly-eNg" firstAttribute="top" secondItem="r8g-wx-lKz" secondAttribute="top" id="uBO-He-Hwq"/>
                         </constraints>
                     </view>
-                    <navigationItem key="navigationItem" id="cin-uB-pCl"/>
                     <connections>
-                        <outlet property="avatarImageView" destination="Utg-8F-B0A" id="CLH-ys-PNd"/>
-                        <outlet property="blurEffectBackground" destination="iGU-ar-QBa" id="QaR-C4-8Fo"/>
-                        <outlet property="descriptionLabel" destination="wfy-1Y-jlW" id="4cq-Cm-Pre"/>
-                        <outlet property="forksCountLabel" destination="V5a-Kr-PTT" id="Hvo-B4-HiM"/>
-                        <outlet property="languageLabel" destination="ebJ-x4-Gpg" id="oey-3j-Nwz"/>
-                        <outlet property="openIssuesCountLabel" destination="3Xu-zY-64o" id="lci-lB-qH8"/>
-                        <outlet property="stargazersCountLabel" destination="WQI-E4-rFR" id="ybx-iD-oH1"/>
-                        <outlet property="titleLabel" destination="KsP-ju-rTn" id="qfq-8B-M24"/>
-                        <outlet property="wachersCountLabel" destination="qF1-59-DTt" id="Uem-Ln-K0g"/>
+                        <outlet property="avatarImageView" destination="a0m-Bh-z32" id="bLd-O6-cxf"/>
+                        <outlet property="blurEffectBackground" destination="FW9-Jg-tmn" id="A79-8P-g9A"/>
+                        <outlet property="cardViewTopConstraint" destination="TVy-XP-4bG" id="rlz-4d-OVD"/>
+                        <outlet property="descriptionLabel" destination="qUk-nT-bqJ" id="Zl5-cP-lhO"/>
+                        <outlet property="forksCountLabel" destination="Wkn-pu-8Uc" id="hzE-0g-SJh"/>
+                        <outlet property="languageLabel" destination="m5r-09-aIc" id="JAa-Mp-D0l"/>
+                        <outlet property="openIssuesCountLabel" destination="UkU-LY-9Ht" id="xVx-8w-Mgr"/>
+                        <outlet property="stargazersCountLabel" destination="bLp-4k-rV1" id="34o-hA-7w6"/>
+                        <outlet property="titleLabel" destination="qER-dV-dCF" id="8uq-ED-e8B"/>
+                        <outlet property="wachersCountLabel" destination="erk-jg-HYt" id="IqY-ex-MNn"/>
                     </connections>
                 </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="q4a-53-mLL" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="0Je-cH-Oy6" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="230" y="137"/>
+            <point key="canvasLocation" x="-1055.072463768116" y="136.60714285714286"/>
         </scene>
     </scenes>
     <resources>

--- a/iOSEngineerCodeCheck/UserInterface/RepositoryDetail/RepositoryDetail.storyboard
+++ b/iOSEngineerCodeCheck/UserInterface/RepositoryDetail/RepositoryDetail.storyboard
@@ -17,7 +17,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="iGU-ar-QBa" customClass="BlurEffectView" customModule="iOSEngineerCodeCheck" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="0.0" width="414" height="363"/>
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="367"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="FA5-zu-hgT" customClass="CardView" customModule="iOSEngineerCodeCheck" customModuleProvider="target">
@@ -39,7 +39,7 @@
                                 </constraints>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KsP-ju-rTn">
-                                <rect key="frame" x="16" y="284" width="382" height="35"/>
+                                <rect key="frame" x="16" y="264" width="382" height="35"/>
                                 <accessibility key="accessibilityConfiguration" identifier="TitleLabel"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="35" id="8SF-9z-gNR"/>
@@ -49,7 +49,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wfy-1Y-jlW">
-                                <rect key="frame" x="16" y="327" width="382" height="20"/>
+                                <rect key="frame" x="16" y="307" width="382" height="20"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="20" id="YyU-iA-Tce"/>
                                 </constraints>
@@ -58,46 +58,98 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="CME-ZA-M8T">
-                                <rect key="frame" x="16" y="403" width="382" height="106"/>
+                                <rect key="frame" x="16" y="407" width="382" height="161"/>
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Language" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ebJ-x4-Gpg">
-                                        <rect key="frame" x="0.0" y="0.0" width="66.5" height="17"/>
-                                        <accessibility key="accessibilityConfiguration" identifier="LanguageLabel"/>
-                                        <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
-                                        <color key="textColor" systemColor="darkTextColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="aVB-8r-8BG">
-                                        <rect key="frame" x="328.5" y="0.0" width="53.5" height="106"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="382" height="161"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Stars" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WQI-E4-rFR">
-                                                <rect key="frame" x="0.0" y="0.0" width="53.5" height="14.5"/>
-                                                <accessibility key="accessibilityConfiguration" identifier="StargazersCountLabel"/>
-                                                <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Language" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ebJ-x4-Gpg">
+                                                <rect key="frame" x="0.0" y="0.0" width="382" height="17"/>
+                                                <accessibility key="accessibilityConfiguration" identifier="LanguageLabel"/>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                 <color key="textColor" systemColor="darkTextColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Wathcers" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qF1-59-DTt">
-                                                <rect key="frame" x="0.0" y="30.5" width="53.5" height="14.5"/>
-                                                <accessibility key="accessibilityConfiguration" identifier="WachersCountLabel"/>
-                                                <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                                                <color key="textColor" systemColor="darkTextColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Forks" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="V5a-Kr-PTT">
-                                                <rect key="frame" x="0.0" y="61" width="53.5" height="14.5"/>
-                                                <accessibility key="accessibilityConfiguration" identifier="ForksCountLabel"/>
-                                                <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                                                <color key="textColor" systemColor="darkTextColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Issues" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3Xu-zY-64o">
-                                                <rect key="frame" x="0.0" y="91.5" width="53.5" height="14.5"/>
-                                                <accessibility key="accessibilityConfiguration" identifier="OpenIssuesCountLabel"/>
-                                                <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                                                <color key="textColor" systemColor="darkTextColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
+                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="ncj-Fg-HA8">
+                                                <rect key="frame" x="0.0" y="33" width="382" height="20"/>
+                                                <subviews>
+                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="star" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="u4J-MH-5Kf">
+                                                        <rect key="frame" x="0.0" y="-0.5" width="20" height="20"/>
+                                                        <color key="tintColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="width" constant="20" id="V3j-Q3-6pX"/>
+                                                            <constraint firstAttribute="height" constant="20" id="Zrv-tb-gAD"/>
+                                                        </constraints>
+                                                    </imageView>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Stars" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WQI-E4-rFR">
+                                                        <rect key="frame" x="24" y="0.0" width="358" height="20"/>
+                                                        <accessibility key="accessibilityConfiguration" identifier="StargazersCountLabel"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                                        <color key="textColor" systemColor="darkTextColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                            </stackView>
+                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="Hdr-r5-E5I">
+                                                <rect key="frame" x="0.0" y="69" width="382" height="20"/>
+                                                <subviews>
+                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="eye" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="ZvB-ui-5yG">
+                                                        <rect key="frame" x="0.0" y="1.5" width="20" height="16.5"/>
+                                                        <color key="tintColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="20" id="LVa-Xl-Ill"/>
+                                                            <constraint firstAttribute="width" constant="20" id="e4S-yV-Bon"/>
+                                                        </constraints>
+                                                    </imageView>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Wathcers" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qF1-59-DTt">
+                                                        <rect key="frame" x="24" y="0.0" width="358" height="20"/>
+                                                        <accessibility key="accessibilityConfiguration" identifier="WachersCountLabel"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                                        <color key="textColor" systemColor="darkTextColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                            </stackView>
+                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="hie-Kj-2A0">
+                                                <rect key="frame" x="0.0" y="105" width="382" height="20"/>
+                                                <subviews>
+                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="point.topleft.down.curvedto.point.bottomright.up" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="Xe1-B7-Wqk">
+                                                        <rect key="frame" x="0.0" y="0.0" width="20" height="20"/>
+                                                        <color key="tintColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="width" constant="20" id="7TN-4L-f47"/>
+                                                            <constraint firstAttribute="height" constant="20" id="Vnw-Pj-EAJ"/>
+                                                        </constraints>
+                                                    </imageView>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Forks" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="V5a-Kr-PTT">
+                                                        <rect key="frame" x="24" y="0.0" width="358" height="20"/>
+                                                        <accessibility key="accessibilityConfiguration" identifier="ForksCountLabel"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                                        <color key="textColor" systemColor="darkTextColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                            </stackView>
+                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="YwG-gV-MuV">
+                                                <rect key="frame" x="0.0" y="141" width="382" height="20"/>
+                                                <subviews>
+                                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="smallcircle.filled.circle" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="v4S-3I-Nww">
+                                                        <rect key="frame" x="0.0" y="0.5" width="20" height="19"/>
+                                                        <color key="tintColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="20" id="GWX-Zl-8rz"/>
+                                                            <constraint firstAttribute="width" constant="20" id="hCw-rn-RTm"/>
+                                                        </constraints>
+                                                    </imageView>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Issues" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3Xu-zY-64o">
+                                                        <rect key="frame" x="24" y="0.0" width="358" height="20"/>
+                                                        <accessibility key="accessibilityConfiguration" identifier="OpenIssuesCountLabel"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                                        <color key="textColor" systemColor="darkTextColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                            </stackView>
                                         </subviews>
                                     </stackView>
                                 </subviews>
@@ -115,13 +167,13 @@
                             <constraint firstItem="KsP-ju-rTn" firstAttribute="leading" secondItem="d8v-Sh-p7w" secondAttribute="leading" constant="16" id="Xoh-z5-jmV"/>
                             <constraint firstItem="FA5-zu-hgT" firstAttribute="top" secondItem="d8v-Sh-p7w" secondAttribute="top" id="aom-9D-52Z"/>
                             <constraint firstItem="d8v-Sh-p7w" firstAttribute="trailing" secondItem="iGU-ar-QBa" secondAttribute="trailing" id="eEz-6K-alp"/>
-                            <constraint firstItem="wfy-1Y-jlW" firstAttribute="bottom" secondItem="iGU-ar-QBa" secondAttribute="bottom" constant="-16" id="hKF-vy-2vT"/>
+                            <constraint firstItem="wfy-1Y-jlW" firstAttribute="bottom" secondItem="iGU-ar-QBa" secondAttribute="bottom" constant="-40" id="hKF-vy-2vT"/>
                             <constraint firstItem="wfy-1Y-jlW" firstAttribute="top" secondItem="KsP-ju-rTn" secondAttribute="bottom" constant="8" id="kJE-5X-mYu"/>
                             <constraint firstItem="CME-ZA-M8T" firstAttribute="top" secondItem="iGU-ar-QBa" secondAttribute="bottom" constant="40" id="m7M-LG-G9F"/>
                             <constraint firstItem="FA5-zu-hgT" firstAttribute="centerX" secondItem="wCv-FG-8ah" secondAttribute="centerX" id="p9K-1I-CGC"/>
                             <constraint firstItem="iGU-ar-QBa" firstAttribute="top" secondItem="wCv-FG-8ah" secondAttribute="top" id="qik-cg-fvU"/>
                             <constraint firstItem="iGU-ar-QBa" firstAttribute="leading" secondItem="d8v-Sh-p7w" secondAttribute="leading" id="sZK-9R-OFF"/>
-                            <constraint firstItem="KsP-ju-rTn" firstAttribute="top" secondItem="FA5-zu-hgT" secondAttribute="bottom" constant="40" id="xZR-49-AZg"/>
+                            <constraint firstItem="KsP-ju-rTn" firstAttribute="top" secondItem="FA5-zu-hgT" secondAttribute="bottom" constant="20" id="xZR-49-AZg"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="cin-uB-pCl"/>
@@ -143,6 +195,10 @@
         </scene>
     </scenes>
     <resources>
+        <image name="eye" catalog="system" width="128" height="81"/>
+        <image name="point.topleft.down.curvedto.point.bottomright.up" catalog="system" width="121" height="128"/>
+        <image name="smallcircle.filled.circle" catalog="system" width="128" height="121"/>
+        <image name="star" catalog="system" width="128" height="116"/>
         <systemColor name="darkTextColor">
             <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/iOSEngineerCodeCheck/UserInterface/RepositoryDetail/RepositoryDetail.storyboard
+++ b/iOSEngineerCodeCheck/UserInterface/RepositoryDetail/RepositoryDetail.storyboard
@@ -17,7 +17,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="iGU-ar-QBa" customClass="BlurEffectView" customModule="iOSEngineerCodeCheck" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="0.0" width="414" height="358.5"/>
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="393"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="FA5-zu-hgT" customClass="CardView" customModule="iOSEngineerCodeCheck" customModuleProvider="target">
@@ -38,15 +38,27 @@
                                     <constraint firstItem="Utg-8F-B0A" firstAttribute="leading" secondItem="FA5-zu-hgT" secondAttribute="leading" id="w4p-fR-fb5"/>
                                 </constraints>
                             </view>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KsP-ju-rTn">
-                                <rect key="frame" x="184" y="284" width="46.5" height="30"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KsP-ju-rTn">
+                                <rect key="frame" x="16" y="284" width="382" height="35"/>
                                 <accessibility key="accessibilityConfiguration" identifier="TitleLabel"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="35" id="8SF-9z-gNR"/>
+                                </constraints>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                 <color key="textColor" systemColor="darkTextColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wfy-1Y-jlW">
+                                <rect key="frame" x="16" y="327" width="382" height="50"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="50" id="h8H-uD-ssP"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                             <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="CME-ZA-M8T">
-                                <rect key="frame" x="16" y="336" width="382" height="106"/>
+                                <rect key="frame" x="16" y="433" width="382" height="106"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Language" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ebJ-x4-Gpg">
                                         <rect key="frame" x="0.0" y="0.0" width="66.5" height="17"/>
@@ -94,13 +106,18 @@
                         <viewLayoutGuide key="safeArea" id="d8v-Sh-p7w"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
+                            <constraint firstItem="d8v-Sh-p7w" firstAttribute="trailing" secondItem="KsP-ju-rTn" secondAttribute="trailing" constant="16" id="0Q9-cw-2T3"/>
                             <constraint firstItem="CME-ZA-M8T" firstAttribute="leading" secondItem="d8v-Sh-p7w" secondAttribute="leading" constant="16" id="2m8-sT-YcO"/>
                             <constraint firstItem="d8v-Sh-p7w" firstAttribute="trailing" secondItem="CME-ZA-M8T" secondAttribute="trailing" constant="16" id="30I-3X-d8k"/>
-                            <constraint firstItem="CME-ZA-M8T" firstAttribute="top" secondItem="KsP-ju-rTn" secondAttribute="bottom" constant="22" id="3fF-He-38l"/>
+                            <constraint firstItem="wfy-1Y-jlW" firstAttribute="centerX" secondItem="wCv-FG-8ah" secondAttribute="centerX" id="5nR-6i-ro8"/>
+                            <constraint firstItem="wfy-1Y-jlW" firstAttribute="leading" secondItem="d8v-Sh-p7w" secondAttribute="leading" constant="16" id="EGF-GM-wg9"/>
+                            <constraint firstItem="d8v-Sh-p7w" firstAttribute="trailing" secondItem="wfy-1Y-jlW" secondAttribute="trailing" constant="16" id="QY7-YA-cMs"/>
+                            <constraint firstItem="KsP-ju-rTn" firstAttribute="leading" secondItem="d8v-Sh-p7w" secondAttribute="leading" constant="16" id="Xoh-z5-jmV"/>
                             <constraint firstItem="FA5-zu-hgT" firstAttribute="top" secondItem="d8v-Sh-p7w" secondAttribute="top" id="aom-9D-52Z"/>
                             <constraint firstItem="d8v-Sh-p7w" firstAttribute="trailing" secondItem="iGU-ar-QBa" secondAttribute="trailing" id="eEz-6K-alp"/>
-                            <constraint firstItem="CME-ZA-M8T" firstAttribute="centerX" secondItem="KsP-ju-rTn" secondAttribute="centerX" id="hfK-p0-LsI"/>
-                            <constraint firstItem="iGU-ar-QBa" firstAttribute="height" secondItem="wCv-FG-8ah" secondAttribute="height" multiplier="0.4" id="hio-z2-Md9"/>
+                            <constraint firstItem="wfy-1Y-jlW" firstAttribute="bottom" secondItem="iGU-ar-QBa" secondAttribute="bottom" constant="-16" id="hKF-vy-2vT"/>
+                            <constraint firstItem="wfy-1Y-jlW" firstAttribute="top" secondItem="KsP-ju-rTn" secondAttribute="bottom" constant="8" id="kJE-5X-mYu"/>
+                            <constraint firstItem="CME-ZA-M8T" firstAttribute="top" secondItem="iGU-ar-QBa" secondAttribute="bottom" constant="40" id="m7M-LG-G9F"/>
                             <constraint firstItem="FA5-zu-hgT" firstAttribute="centerX" secondItem="wCv-FG-8ah" secondAttribute="centerX" id="p9K-1I-CGC"/>
                             <constraint firstItem="iGU-ar-QBa" firstAttribute="top" secondItem="wCv-FG-8ah" secondAttribute="top" id="qik-cg-fvU"/>
                             <constraint firstItem="iGU-ar-QBa" firstAttribute="leading" secondItem="d8v-Sh-p7w" secondAttribute="leading" id="sZK-9R-OFF"/>
@@ -111,6 +128,7 @@
                     <connections>
                         <outlet property="avatarImageView" destination="Utg-8F-B0A" id="CLH-ys-PNd"/>
                         <outlet property="blurEffectBackground" destination="iGU-ar-QBa" id="QaR-C4-8Fo"/>
+                        <outlet property="descriptionLabel" destination="wfy-1Y-jlW" id="4cq-Cm-Pre"/>
                         <outlet property="forksCountLabel" destination="V5a-Kr-PTT" id="Hvo-B4-HiM"/>
                         <outlet property="languageLabel" destination="ebJ-x4-Gpg" id="oey-3j-Nwz"/>
                         <outlet property="openIssuesCountLabel" destination="3Xu-zY-64o" id="lci-lB-qH8"/>

--- a/iOSEngineerCodeCheck/UserInterface/RepositoryDetail/RepositoryDetail.storyboard
+++ b/iOSEngineerCodeCheck/UserInterface/RepositoryDetail/RepositoryDetail.storyboard
@@ -20,10 +20,10 @@
                                 <rect key="frame" x="0.0" y="0.0" width="414" height="862"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="UCT-cv-sfg">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="700"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="726"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="FW9-Jg-tmn" customClass="BlurEffectView" customModule="iOSEngineerCodeCheck" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="-100" width="414" height="467"/>
+                                                <rect key="frame" x="0.0" y="-100" width="414" height="479"/>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                             </view>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2zO-KN-Vw8" customClass="CardView" customModule="iOSEngineerCodeCheck" customModuleProvider="target">
@@ -54,51 +54,54 @@
                                                 <color key="textColor" systemColor="darkTextColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qUk-nT-bqJ">
-                                                <rect key="frame" x="16" y="307" width="382" height="20"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="20" id="dMh-Tn-ywC"/>
-                                                </constraints>
-                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                                <nil key="textColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
+                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="aed-6x-G0I">
+                                                <rect key="frame" x="124.5" y="319" width="165.5" height="20"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="Language:" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gn7-cN-bny">
+                                                        <rect key="frame" x="0.0" y="0.0" width="86" height="20"/>
+                                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Language" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="m5r-09-aIc">
+                                                        <rect key="frame" x="90" y="0.0" width="75.5" height="20"/>
+                                                        <accessibility key="accessibilityConfiguration" identifier="LanguageLabel"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="20" id="Xej-Ep-23R"/>
+                                                        </constraints>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                            </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="ZPx-bY-Rgt">
-                                                <rect key="frame" x="16" y="387" width="382" height="249"/>
+                                                <rect key="frame" x="16" y="395" width="382" height="291"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="MHs-eQ-CAq">
-                                                        <rect key="frame" x="0.0" y="0.0" width="382" height="249"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="382" height="291"/>
                                                         <subviews>
-                                                            <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aed-6x-G0I">
-                                                                <rect key="frame" x="0.0" y="0.0" width="382" height="20"/>
-                                                                <subviews>
-                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="Language" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gn7-cN-bny">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="306.5" height="20"/>
-                                                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
-                                                                        <nil key="textColor"/>
-                                                                        <nil key="highlightedColor"/>
-                                                                    </label>
-                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Language" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="m5r-09-aIc">
-                                                                        <rect key="frame" x="306.5" y="0.0" width="75.5" height="20"/>
-                                                                        <accessibility key="accessibilityConfiguration" identifier="LanguageLabel"/>
-                                                                        <constraints>
-                                                                            <constraint firstAttribute="height" constant="20" id="Xej-Ep-23R"/>
-                                                                        </constraints>
-                                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                                        <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                                        <nil key="highlightedColor"/>
-                                                                    </label>
-                                                                </subviews>
-                                                            </stackView>
-                                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="g26-gB-siR">
-                                                                <rect key="frame" x="0.0" y="36" width="382" height="1"/>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qUk-nT-bqJ">
+                                                                <rect key="frame" x="0.0" y="0.0" width="382" height="17"/>
+                                                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                                                <nil key="textColor"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Fpf-BA-aIZ">
+                                                                <rect key="frame" x="0.0" y="33" width="382" height="1"/>
                                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                                 <constraints>
-                                                                    <constraint firstAttribute="height" constant="1" id="gPa-CR-tRV"/>
+                                                                    <constraint firstAttribute="height" constant="1" id="EYr-k8-U9B"/>
                                                                 </constraints>
                                                             </view>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Information" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Sut-bf-P2f">
+                                                                <rect key="frame" x="0.0" y="50" width="382" height="29"/>
+                                                                <fontDescription key="fontDescription" type="boldSystem" pointSize="24"/>
+                                                                <nil key="textColor"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
                                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="ba3-Ye-azF">
-                                                                <rect key="frame" x="0.0" y="53" width="382" height="20"/>
+                                                                <rect key="frame" x="0.0" y="95" width="382" height="20"/>
                                                                 <subviews>
                                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="star" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="KrV-EW-oxi">
                                                                         <rect key="frame" x="0.0" y="-0.5" width="20" height="20"/>
@@ -124,14 +127,14 @@
                                                                 </subviews>
                                                             </stackView>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hZk-lJ-P6W">
-                                                                <rect key="frame" x="0.0" y="89" width="382" height="1"/>
+                                                                <rect key="frame" x="0.0" y="131" width="382" height="1"/>
                                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="1" id="0Og-09-L7H"/>
                                                                 </constraints>
                                                             </view>
                                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="gpA-Ou-N3d">
-                                                                <rect key="frame" x="0.0" y="106" width="382" height="20"/>
+                                                                <rect key="frame" x="0.0" y="148" width="382" height="20"/>
                                                                 <subviews>
                                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="eye" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="zW8-V7-i53">
                                                                         <rect key="frame" x="0.0" y="1.5" width="20" height="16.5"/>
@@ -157,14 +160,14 @@
                                                                 </subviews>
                                                             </stackView>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="kzr-dE-3Xd">
-                                                                <rect key="frame" x="0.0" y="142" width="382" height="1"/>
+                                                                <rect key="frame" x="0.0" y="184" width="382" height="1"/>
                                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="1" id="2Md-SM-AiF"/>
                                                                 </constraints>
                                                             </view>
                                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="emo-88-dI2">
-                                                                <rect key="frame" x="0.0" y="159" width="382" height="20"/>
+                                                                <rect key="frame" x="0.0" y="201" width="382" height="20"/>
                                                                 <subviews>
                                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="point.topleft.down.curvedto.point.bottomright.up" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="kdc-Y9-xli">
                                                                         <rect key="frame" x="0.0" y="0.0" width="20" height="20"/>
@@ -190,14 +193,14 @@
                                                                 </subviews>
                                                             </stackView>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="EQ9-zS-oDd">
-                                                                <rect key="frame" x="0.0" y="195" width="382" height="1"/>
+                                                                <rect key="frame" x="0.0" y="237" width="382" height="1"/>
                                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="1" id="QKL-Nd-D2L"/>
                                                                 </constraints>
                                                             </view>
                                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="zNi-KU-b6g">
-                                                                <rect key="frame" x="0.0" y="212" width="382" height="20"/>
+                                                                <rect key="frame" x="0.0" y="254" width="382" height="20"/>
                                                                 <subviews>
                                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="smallcircle.filled.circle" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="KbJ-bd-166">
                                                                         <rect key="frame" x="0.0" y="0.5" width="20" height="19"/>
@@ -223,7 +226,7 @@
                                                                 </subviews>
                                                             </stackView>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="91p-zp-dcY">
-                                                                <rect key="frame" x="0.0" y="248" width="382" height="1"/>
+                                                                <rect key="frame" x="0.0" y="290" width="382" height="1"/>
                                                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="1" id="nUl-jK-ChD"/>
@@ -236,34 +239,32 @@
                                         </subviews>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
-                                            <constraint firstAttribute="trailing" secondItem="qUk-nT-bqJ" secondAttribute="trailing" constant="16" id="1mT-cw-RoQ"/>
                                             <constraint firstAttribute="trailing" secondItem="FW9-Jg-tmn" secondAttribute="trailing" id="6gV-qy-25b"/>
                                             <constraint firstItem="qER-dV-dCF" firstAttribute="top" secondItem="2zO-KN-Vw8" secondAttribute="bottom" constant="20" id="BIT-Ck-25S"/>
-                                            <constraint firstItem="qUk-nT-bqJ" firstAttribute="leading" secondItem="UCT-cv-sfg" secondAttribute="leading" constant="16" id="GZl-Ks-b3H"/>
                                             <constraint firstItem="FW9-Jg-tmn" firstAttribute="top" secondItem="UCT-cv-sfg" secondAttribute="top" constant="-100" id="LwX-Av-qaA"/>
                                             <constraint firstItem="2zO-KN-Vw8" firstAttribute="top" secondItem="UCT-cv-sfg" secondAttribute="top" constant="44" id="TVy-XP-4bG"/>
-                                            <constraint firstItem="qUk-nT-bqJ" firstAttribute="bottom" secondItem="FW9-Jg-tmn" secondAttribute="bottom" constant="-40" id="U5M-Lt-Pc2"/>
+                                            <constraint firstAttribute="bottom" secondItem="ZPx-bY-Rgt" secondAttribute="bottom" constant="40" id="VLL-fi-OJd"/>
+                                            <constraint firstItem="aed-6x-G0I" firstAttribute="centerX" secondItem="UCT-cv-sfg" secondAttribute="centerX" id="XsU-fg-Gsv"/>
+                                            <constraint firstItem="aed-6x-G0I" firstAttribute="top" secondItem="qER-dV-dCF" secondAttribute="bottom" constant="20" id="bRq-so-TJm"/>
                                             <constraint firstItem="2zO-KN-Vw8" firstAttribute="centerX" secondItem="UCT-cv-sfg" secondAttribute="centerX" id="dUF-nm-krq"/>
                                             <constraint firstItem="qER-dV-dCF" firstAttribute="leading" secondItem="UCT-cv-sfg" secondAttribute="leading" constant="16" id="eXM-I6-glu"/>
                                             <constraint firstAttribute="trailing" secondItem="qER-dV-dCF" secondAttribute="trailing" constant="16" id="h3g-As-XLg"/>
                                             <constraint firstItem="FW9-Jg-tmn" firstAttribute="leading" secondItem="UCT-cv-sfg" secondAttribute="leading" id="hgq-Ky-ufj"/>
-                                            <constraint firstItem="ZPx-bY-Rgt" firstAttribute="top" secondItem="FW9-Jg-tmn" secondAttribute="bottom" constant="20" id="kzt-pN-Qve"/>
-                                            <constraint firstItem="qUk-nT-bqJ" firstAttribute="top" secondItem="qER-dV-dCF" secondAttribute="bottom" constant="8" id="oCG-I8-AbX"/>
-                                            <constraint firstAttribute="height" constant="700" id="r8w-L3-crB"/>
+                                            <constraint firstItem="ZPx-bY-Rgt" firstAttribute="top" secondItem="FW9-Jg-tmn" secondAttribute="bottom" constant="16" id="kzt-pN-Qve"/>
+                                            <constraint firstItem="aed-6x-G0I" firstAttribute="bottom" secondItem="FW9-Jg-tmn" secondAttribute="bottom" constant="-40" id="q3v-3L-EKg"/>
                                             <constraint firstItem="ZPx-bY-Rgt" firstAttribute="leading" secondItem="UCT-cv-sfg" secondAttribute="leading" constant="16" id="xXJ-tx-0na"/>
                                             <constraint firstAttribute="trailing" secondItem="ZPx-bY-Rgt" secondAttribute="trailing" constant="16" id="yfo-xg-UoC"/>
                                         </constraints>
                                     </view>
                                 </subviews>
                                 <constraints>
-                                    <constraint firstItem="UCT-cv-sfg" firstAttribute="width" secondItem="00E-A4-Fwr" secondAttribute="width" id="MsI-bO-tum"/>
-                                    <constraint firstItem="UCT-cv-sfg" firstAttribute="trailing" secondItem="KPS-PU-isI" secondAttribute="trailing" id="i7d-u7-aWd"/>
-                                    <constraint firstItem="UCT-cv-sfg" firstAttribute="bottom" secondItem="KPS-PU-isI" secondAttribute="bottom" id="iDc-TC-5Mf"/>
-                                    <constraint firstItem="UCT-cv-sfg" firstAttribute="top" secondItem="KPS-PU-isI" secondAttribute="top" id="llf-RE-I11"/>
-                                    <constraint firstItem="UCT-cv-sfg" firstAttribute="leading" secondItem="KPS-PU-isI" secondAttribute="leading" id="u7R-5j-ce7"/>
+                                    <constraint firstItem="UCT-cv-sfg" firstAttribute="width" secondItem="XQ1-Ly-eNg" secondAttribute="width" id="MsI-bO-tum"/>
+                                    <constraint firstItem="UCT-cv-sfg" firstAttribute="bottom" secondItem="XQ1-Ly-eNg" secondAttribute="bottom" id="VbU-sB-YD6"/>
+                                    <constraint firstItem="UCT-cv-sfg" firstAttribute="trailing" secondItem="XQ1-Ly-eNg" secondAttribute="trailing" id="i7d-u7-aWd"/>
+                                    <constraint firstItem="UCT-cv-sfg" firstAttribute="bottom" secondItem="XQ1-Ly-eNg" secondAttribute="bottom" id="iDc-TC-5Mf"/>
+                                    <constraint firstItem="UCT-cv-sfg" firstAttribute="top" secondItem="XQ1-Ly-eNg" secondAttribute="top" id="llf-RE-I11"/>
+                                    <constraint firstItem="UCT-cv-sfg" firstAttribute="leading" secondItem="XQ1-Ly-eNg" secondAttribute="leading" id="u7R-5j-ce7"/>
                                 </constraints>
-                                <viewLayoutGuide key="contentLayoutGuide" id="KPS-PU-isI"/>
-                                <viewLayoutGuide key="frameLayoutGuide" id="00E-A4-Fwr"/>
                             </scrollView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="VSd-2u-98q"/>

--- a/iOSEngineerCodeCheck/UserInterface/RepositoryDetail/RepositoryDetail.storyboard
+++ b/iOSEngineerCodeCheck/UserInterface/RepositoryDetail/RepositoryDetail.storyboard
@@ -16,22 +16,37 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Utg-8F-B0A">
-                                <rect key="frame" x="20" y="130" width="374" height="374"/>
-                                <accessibility key="accessibilityConfiguration" identifier="AvatarImage"/>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="iGU-ar-QBa" customClass="BlurEffectView" customModule="iOSEngineerCodeCheck" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="358.5"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                            </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="FA5-zu-hgT" customClass="CardView" customModule="iOSEngineerCodeCheck" customModuleProvider="target">
+                                <rect key="frame" x="107" y="44" width="200" height="200"/>
+                                <subviews>
+                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Utg-8F-B0A">
+                                        <rect key="frame" x="0.0" y="0.0" width="200" height="200"/>
+                                        <accessibility key="accessibilityConfiguration" identifier="AvatarImage"/>
+                                    </imageView>
+                                </subviews>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
-                                    <constraint firstAttribute="width" secondItem="Utg-8F-B0A" secondAttribute="height" multiplier="1:1" id="hG1-4x-kWl"/>
+                                    <constraint firstItem="Utg-8F-B0A" firstAttribute="top" secondItem="FA5-zu-hgT" secondAttribute="top" id="90c-kM-b3e"/>
+                                    <constraint firstAttribute="trailing" secondItem="Utg-8F-B0A" secondAttribute="trailing" id="OkK-Ue-EoZ"/>
+                                    <constraint firstAttribute="bottom" secondItem="Utg-8F-B0A" secondAttribute="bottom" id="RGj-fO-EfI"/>
+                                    <constraint firstAttribute="width" constant="200" id="mWD-Hb-hS4"/>
+                                    <constraint firstAttribute="height" constant="200" id="rdT-WT-wIk"/>
+                                    <constraint firstItem="Utg-8F-B0A" firstAttribute="leading" secondItem="FA5-zu-hgT" secondAttribute="leading" id="w4p-fR-fb5"/>
                                 </constraints>
-                            </imageView>
+                            </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KsP-ju-rTn">
-                                <rect key="frame" x="184" y="532" width="46.5" height="30"/>
+                                <rect key="frame" x="184" y="284" width="46.5" height="30"/>
                                 <accessibility key="accessibilityConfiguration" identifier="TitleLabel"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                 <color key="textColor" systemColor="darkTextColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="CME-ZA-M8T">
-                                <rect key="frame" x="20" y="584" width="374" height="106"/>
+                                <rect key="frame" x="16" y="336" width="382" height="106"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Language" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ebJ-x4-Gpg">
                                         <rect key="frame" x="0.0" y="0.0" width="66.5" height="17"/>
@@ -41,7 +56,7 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="aVB-8r-8BG">
-                                        <rect key="frame" x="320.5" y="0.0" width="53.5" height="106"/>
+                                        <rect key="frame" x="328.5" y="0.0" width="53.5" height="106"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Stars" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WQI-E4-rFR">
                                                 <rect key="frame" x="0.0" y="0.0" width="53.5" height="14.5"/>
@@ -79,19 +94,23 @@
                         <viewLayoutGuide key="safeArea" id="d8v-Sh-p7w"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
+                            <constraint firstItem="CME-ZA-M8T" firstAttribute="leading" secondItem="d8v-Sh-p7w" secondAttribute="leading" constant="16" id="2m8-sT-YcO"/>
+                            <constraint firstItem="d8v-Sh-p7w" firstAttribute="trailing" secondItem="CME-ZA-M8T" secondAttribute="trailing" constant="16" id="30I-3X-d8k"/>
                             <constraint firstItem="CME-ZA-M8T" firstAttribute="top" secondItem="KsP-ju-rTn" secondAttribute="bottom" constant="22" id="3fF-He-38l"/>
-                            <constraint firstItem="d8v-Sh-p7w" firstAttribute="trailing" secondItem="Utg-8F-B0A" secondAttribute="trailing" constant="20" id="5gl-K1-Rws"/>
-                            <constraint firstItem="Utg-8F-B0A" firstAttribute="centerY" secondItem="d8v-Sh-p7w" secondAttribute="centerY" multiplier="0.7" id="DTc-Zu-6qG"/>
-                            <constraint firstItem="CME-ZA-M8T" firstAttribute="width" secondItem="Utg-8F-B0A" secondAttribute="width" id="hZt-Lp-2Nx"/>
+                            <constraint firstItem="FA5-zu-hgT" firstAttribute="top" secondItem="d8v-Sh-p7w" secondAttribute="top" id="aom-9D-52Z"/>
+                            <constraint firstItem="d8v-Sh-p7w" firstAttribute="trailing" secondItem="iGU-ar-QBa" secondAttribute="trailing" id="eEz-6K-alp"/>
                             <constraint firstItem="CME-ZA-M8T" firstAttribute="centerX" secondItem="KsP-ju-rTn" secondAttribute="centerX" id="hfK-p0-LsI"/>
-                            <constraint firstItem="KsP-ju-rTn" firstAttribute="top" secondItem="Utg-8F-B0A" secondAttribute="bottom" constant="28" id="psT-b3-ThG"/>
-                            <constraint firstItem="Utg-8F-B0A" firstAttribute="leading" secondItem="d8v-Sh-p7w" secondAttribute="leading" constant="20" id="reo-qd-8PJ"/>
-                            <constraint firstItem="KsP-ju-rTn" firstAttribute="centerX" secondItem="Utg-8F-B0A" secondAttribute="centerX" id="rnd-lv-QQ3"/>
+                            <constraint firstItem="iGU-ar-QBa" firstAttribute="height" secondItem="wCv-FG-8ah" secondAttribute="height" multiplier="0.4" id="hio-z2-Md9"/>
+                            <constraint firstItem="FA5-zu-hgT" firstAttribute="centerX" secondItem="wCv-FG-8ah" secondAttribute="centerX" id="p9K-1I-CGC"/>
+                            <constraint firstItem="iGU-ar-QBa" firstAttribute="top" secondItem="wCv-FG-8ah" secondAttribute="top" id="qik-cg-fvU"/>
+                            <constraint firstItem="iGU-ar-QBa" firstAttribute="leading" secondItem="d8v-Sh-p7w" secondAttribute="leading" id="sZK-9R-OFF"/>
+                            <constraint firstItem="KsP-ju-rTn" firstAttribute="top" secondItem="FA5-zu-hgT" secondAttribute="bottom" constant="40" id="xZR-49-AZg"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="cin-uB-pCl"/>
                     <connections>
                         <outlet property="avatarImageView" destination="Utg-8F-B0A" id="CLH-ys-PNd"/>
+                        <outlet property="blurEffectBackground" destination="iGU-ar-QBa" id="QaR-C4-8Fo"/>
                         <outlet property="forksCountLabel" destination="V5a-Kr-PTT" id="Hvo-B4-HiM"/>
                         <outlet property="languageLabel" destination="ebJ-x4-Gpg" id="oey-3j-Nwz"/>
                         <outlet property="openIssuesCountLabel" destination="3Xu-zY-64o" id="lci-lB-qH8"/>

--- a/iOSEngineerCodeCheck/UserInterface/RepositoryDetail/RepositoryDetail.storyboard
+++ b/iOSEngineerCodeCheck/UserInterface/RepositoryDetail/RepositoryDetail.storyboard
@@ -20,7 +20,7 @@
                                 <rect key="frame" x="0.0" y="0.0" width="414" height="862"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="UCT-cv-sfg">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="650"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="700"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="FW9-Jg-tmn" customClass="BlurEffectView" customModule="iOSEngineerCodeCheck" customModuleProvider="target">
                                                 <rect key="frame" x="0.0" y="-100" width="414" height="467"/>
@@ -64,101 +64,171 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="ZPx-bY-Rgt">
-                                                <rect key="frame" x="16" y="387" width="382" height="164"/>
+                                                <rect key="frame" x="16" y="387" width="382" height="249"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="MHs-eQ-CAq">
-                                                        <rect key="frame" x="0.0" y="0.0" width="382" height="164"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="382" height="249"/>
                                                         <subviews>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Language" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="m5r-09-aIc">
+                                                            <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aed-6x-G0I">
                                                                 <rect key="frame" x="0.0" y="0.0" width="382" height="20"/>
-                                                                <accessibility key="accessibilityConfiguration" identifier="LanguageLabel"/>
+                                                                <subviews>
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="Language" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gn7-cN-bny">
+                                                                        <rect key="frame" x="0.0" y="0.0" width="306.5" height="20"/>
+                                                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
+                                                                        <nil key="textColor"/>
+                                                                        <nil key="highlightedColor"/>
+                                                                    </label>
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Language" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="m5r-09-aIc">
+                                                                        <rect key="frame" x="306.5" y="0.0" width="75.5" height="20"/>
+                                                                        <accessibility key="accessibilityConfiguration" identifier="LanguageLabel"/>
+                                                                        <constraints>
+                                                                            <constraint firstAttribute="height" constant="20" id="Xej-Ep-23R"/>
+                                                                        </constraints>
+                                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                                        <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                        <nil key="highlightedColor"/>
+                                                                    </label>
+                                                                </subviews>
+                                                            </stackView>
+                                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="g26-gB-siR">
+                                                                <rect key="frame" x="0.0" y="36" width="382" height="1"/>
+                                                                <color key="backgroundColor" systemColor="systemGray5Color"/>
                                                                 <constraints>
-                                                                    <constraint firstAttribute="height" constant="20" id="Xej-Ep-23R"/>
+                                                                    <constraint firstAttribute="height" constant="1" id="gPa-CR-tRV"/>
                                                                 </constraints>
-                                                                <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
-                                                                <color key="textColor" systemColor="darkTextColor"/>
-                                                                <nil key="highlightedColor"/>
-                                                            </label>
+                                                            </view>
                                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="ba3-Ye-azF">
-                                                                <rect key="frame" x="0.0" y="36" width="382" height="20"/>
+                                                                <rect key="frame" x="0.0" y="53" width="382" height="20"/>
                                                                 <subviews>
                                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="star" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="KrV-EW-oxi">
                                                                         <rect key="frame" x="0.0" y="-0.5" width="20" height="20"/>
-                                                                        <color key="tintColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                        <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="height" constant="20" id="J1g-ph-idj"/>
                                                                             <constraint firstAttribute="width" constant="20" id="gCD-N3-7h4"/>
                                                                         </constraints>
                                                                     </imageView>
-                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Stars" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bLp-4k-rV1">
-                                                                        <rect key="frame" x="24" y="0.0" width="358" height="20"/>
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="Stars" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ARo-am-0p5">
+                                                                        <rect key="frame" x="24" y="0.0" width="314.5" height="20"/>
+                                                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
+                                                                        <nil key="textColor"/>
+                                                                        <nil key="highlightedColor"/>
+                                                                    </label>
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Stars" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bLp-4k-rV1">
+                                                                        <rect key="frame" x="342.5" y="0.0" width="39.5" height="20"/>
                                                                         <accessibility key="accessibilityConfiguration" identifier="StargazersCountLabel"/>
-                                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                                                                        <color key="textColor" systemColor="darkTextColor"/>
+                                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                                        <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                 </subviews>
                                                             </stackView>
+                                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hZk-lJ-P6W">
+                                                                <rect key="frame" x="0.0" y="89" width="382" height="1"/>
+                                                                <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="height" constant="1" id="0Og-09-L7H"/>
+                                                                </constraints>
+                                                            </view>
                                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="gpA-Ou-N3d">
-                                                                <rect key="frame" x="0.0" y="72" width="382" height="20"/>
+                                                                <rect key="frame" x="0.0" y="106" width="382" height="20"/>
                                                                 <subviews>
                                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="eye" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="zW8-V7-i53">
                                                                         <rect key="frame" x="0.0" y="1.5" width="20" height="16.5"/>
-                                                                        <color key="tintColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                        <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="width" constant="20" id="dzY-ww-qpe"/>
                                                                             <constraint firstAttribute="height" constant="20" id="m7V-rr-G4e"/>
                                                                         </constraints>
                                                                     </imageView>
-                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Wathcers" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="erk-jg-HYt">
-                                                                        <rect key="frame" x="24" y="0.0" width="358" height="20"/>
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="Wathcers" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RxK-yh-RMa">
+                                                                        <rect key="frame" x="24" y="0.0" width="281.5" height="20"/>
+                                                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
+                                                                        <nil key="textColor"/>
+                                                                        <nil key="highlightedColor"/>
+                                                                    </label>
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Wathcers" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="erk-jg-HYt">
+                                                                        <rect key="frame" x="309.5" y="0.0" width="72.5" height="20"/>
                                                                         <accessibility key="accessibilityConfiguration" identifier="WachersCountLabel"/>
-                                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                                                                        <color key="textColor" systemColor="darkTextColor"/>
+                                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                                        <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                 </subviews>
                                                             </stackView>
+                                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="kzr-dE-3Xd">
+                                                                <rect key="frame" x="0.0" y="142" width="382" height="1"/>
+                                                                <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="height" constant="1" id="2Md-SM-AiF"/>
+                                                                </constraints>
+                                                            </view>
                                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="emo-88-dI2">
-                                                                <rect key="frame" x="0.0" y="108" width="382" height="20"/>
+                                                                <rect key="frame" x="0.0" y="159" width="382" height="20"/>
                                                                 <subviews>
                                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="point.topleft.down.curvedto.point.bottomright.up" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="kdc-Y9-xli">
                                                                         <rect key="frame" x="0.0" y="0.0" width="20" height="20"/>
-                                                                        <color key="tintColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                        <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="height" constant="20" id="Wuc-If-mOg"/>
                                                                             <constraint firstAttribute="width" constant="20" id="nFU-bC-NGi"/>
                                                                         </constraints>
                                                                     </imageView>
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="Forks" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cre-fy-rQJ">
+                                                                        <rect key="frame" x="24" y="0.0" width="312" height="20"/>
+                                                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
+                                                                        <nil key="textColor"/>
+                                                                        <nil key="highlightedColor"/>
+                                                                    </label>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Forks" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Wkn-pu-8Uc">
-                                                                        <rect key="frame" x="24" y="0.0" width="358" height="20"/>
+                                                                        <rect key="frame" x="340" y="0.0" width="42" height="20"/>
                                                                         <accessibility key="accessibilityConfiguration" identifier="ForksCountLabel"/>
-                                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                                                                        <color key="textColor" systemColor="darkTextColor"/>
+                                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                                        <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                 </subviews>
                                                             </stackView>
+                                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="EQ9-zS-oDd">
+                                                                <rect key="frame" x="0.0" y="195" width="382" height="1"/>
+                                                                <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="height" constant="1" id="QKL-Nd-D2L"/>
+                                                                </constraints>
+                                                            </view>
                                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="zNi-KU-b6g">
-                                                                <rect key="frame" x="0.0" y="144" width="382" height="20"/>
+                                                                <rect key="frame" x="0.0" y="212" width="382" height="20"/>
                                                                 <subviews>
                                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="smallcircle.filled.circle" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="KbJ-bd-166">
                                                                         <rect key="frame" x="0.0" y="0.5" width="20" height="19"/>
-                                                                        <color key="tintColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                        <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="height" constant="20" id="0KQ-dT-Om3"/>
                                                                             <constraint firstAttribute="width" constant="20" id="gMe-IW-sfn"/>
                                                                         </constraints>
                                                                     </imageView>
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalHuggingPriority="251" text="Issues" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nOr-DX-UwS">
+                                                                        <rect key="frame" x="24" y="0.0" width="305.5" height="20"/>
+                                                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="17"/>
+                                                                        <nil key="textColor"/>
+                                                                        <nil key="highlightedColor"/>
+                                                                    </label>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Issues" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UkU-LY-9Ht">
-                                                                        <rect key="frame" x="24" y="0.0" width="358" height="20"/>
+                                                                        <rect key="frame" x="333.5" y="0.0" width="48.5" height="20"/>
                                                                         <accessibility key="accessibilityConfiguration" identifier="OpenIssuesCountLabel"/>
-                                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                                                                        <color key="textColor" systemColor="darkTextColor"/>
+                                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                                        <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                         <nil key="highlightedColor"/>
                                                                     </label>
                                                                 </subviews>
                                                             </stackView>
+                                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="91p-zp-dcY">
+                                                                <rect key="frame" x="0.0" y="248" width="382" height="1"/>
+                                                                <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="height" constant="1" id="nUl-jK-ChD"/>
+                                                                </constraints>
+                                                            </view>
                                                         </subviews>
                                                     </stackView>
                                                 </subviews>
@@ -179,7 +249,7 @@
                                             <constraint firstItem="FW9-Jg-tmn" firstAttribute="leading" secondItem="UCT-cv-sfg" secondAttribute="leading" id="hgq-Ky-ufj"/>
                                             <constraint firstItem="ZPx-bY-Rgt" firstAttribute="top" secondItem="FW9-Jg-tmn" secondAttribute="bottom" constant="20" id="kzt-pN-Qve"/>
                                             <constraint firstItem="qUk-nT-bqJ" firstAttribute="top" secondItem="qER-dV-dCF" secondAttribute="bottom" constant="8" id="oCG-I8-AbX"/>
-                                            <constraint firstAttribute="height" constant="650" id="r8w-L3-crB"/>
+                                            <constraint firstAttribute="height" constant="700" id="r8w-L3-crB"/>
                                             <constraint firstItem="ZPx-bY-Rgt" firstAttribute="leading" secondItem="UCT-cv-sfg" secondAttribute="leading" constant="16" id="xXJ-tx-0na"/>
                                             <constraint firstAttribute="trailing" secondItem="ZPx-bY-Rgt" secondAttribute="trailing" constant="16" id="yfo-xg-UoC"/>
                                         </constraints>
@@ -233,6 +303,9 @@
         </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemGray5Color">
+            <color red="0.89803921568627454" green="0.89803921568627454" blue="0.91764705882352937" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/iOSEngineerCodeCheck/UserInterface/RepositoryDetail/RepositoryDetailViewController.swift
+++ b/iOSEngineerCodeCheck/UserInterface/RepositoryDetail/RepositoryDetailViewController.swift
@@ -38,8 +38,6 @@ class RepositoryDetailViewController: UIViewController {
         let favoriteButton = UIBarButtonItem(image: .init(systemName: "heart"), style: .plain, target: self, action: nil)
         navigationItem.rightBarButtonItem = favoriteButton
         
-        titleLabel.sizeToFit()
-        
         bind()
         guard let repositoryData = store.state.repositoryData else {
             return

--- a/iOSEngineerCodeCheck/UserInterface/RepositoryDetail/RepositoryDetailViewController.swift
+++ b/iOSEngineerCodeCheck/UserInterface/RepositoryDetail/RepositoryDetailViewController.swift
@@ -28,6 +28,7 @@ class RepositoryDetailViewController: UIViewController {
     @IBOutlet weak private var wachersCountLabel: UILabel!
     @IBOutlet weak private var forksCountLabel: UILabel!
     @IBOutlet weak private var openIssuesCountLabel: UILabel!
+    @IBOutlet weak private var cardViewTopConstraint: NSLayoutConstraint!
     
     private var store: Store!
     private var favoriteThunkCreator: FavoriteRepositoryDataThunkCreator!
@@ -39,6 +40,8 @@ class RepositoryDetailViewController: UIViewController {
         
         let favoriteButton = UIBarButtonItem(image: .init(systemName: "heart"), style: .plain, target: self, action: nil)
         navigationItem.rightBarButtonItem = favoriteButton
+        
+        cardViewTopConstraint.constant = navigationController?.navigationBar.frame.size.height ?? 0
         
         bind()
         guard let repositoryData = store.state.repositoryData else {

--- a/iOSEngineerCodeCheck/UserInterface/RepositoryDetail/RepositoryDetailViewController.swift
+++ b/iOSEngineerCodeCheck/UserInterface/RepositoryDetail/RepositoryDetailViewController.swift
@@ -41,7 +41,7 @@ class RepositoryDetailViewController: UIViewController {
         let favoriteButton = UIBarButtonItem(image: .init(systemName: "heart"), style: .plain, target: self, action: nil)
         navigationItem.rightBarButtonItem = favoriteButton
         
-        cardViewTopConstraint.constant = navigationController?.navigationBar.frame.size.height ?? 0
+        cardViewTopConstraint.constant += SceneDelegate.statusBarHeight
         
         bind()
         guard let repositoryData = store.state.repositoryData else {

--- a/iOSEngineerCodeCheck/UserInterface/RepositoryDetail/RepositoryDetailViewController.swift
+++ b/iOSEngineerCodeCheck/UserInterface/RepositoryDetail/RepositoryDetailViewController.swift
@@ -35,6 +35,8 @@ class RepositoryDetailViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        navigationItem.largeTitleDisplayMode = .never
+        
         let favoriteButton = UIBarButtonItem(image: .init(systemName: "heart"), style: .plain, target: self, action: nil)
         navigationItem.rightBarButtonItem = favoriteButton
         

--- a/iOSEngineerCodeCheck/UserInterface/RepositoryDetail/RepositoryDetailViewController.swift
+++ b/iOSEngineerCodeCheck/UserInterface/RepositoryDetail/RepositoryDetailViewController.swift
@@ -144,9 +144,6 @@ extension Reactive where Base: RepositoryDetailViewController.Store {
             .unwrap()
             .distinctUntilChanged()
             .mapAt(\.language)
-            .map { value in
-                "Written in \(value)"
-            }
             .asDriver(onErrorDriveWith: .never())
     }
     
@@ -154,10 +151,7 @@ extension Reactive where Base: RepositoryDetailViewController.Store {
         base.stateObservable.mapAt(\.repositoryData)
             .unwrap()
             .distinctUntilChanged()
-            .mapAt(\.stargazersCount)
-            .map { value in
-                "\(value) stars"
-            }
+            .mapAt(\.stargazersCount.description)
             .asDriver(onErrorDriveWith: .never())
     }
     
@@ -165,10 +159,7 @@ extension Reactive where Base: RepositoryDetailViewController.Store {
         base.stateObservable.mapAt(\.repositoryData)
             .unwrap()
             .distinctUntilChanged()
-            .mapAt(\.watchersCount)
-            .map { value in
-                "\(value) watchers"
-            }
+            .mapAt(\.watchersCount.description)
             .asDriver(onErrorDriveWith: .never())
     }
     
@@ -176,10 +167,7 @@ extension Reactive where Base: RepositoryDetailViewController.Store {
         base.stateObservable.mapAt(\.repositoryData)
             .unwrap()
             .distinctUntilChanged()
-            .mapAt(\.forksCount)
-            .map { value in
-                "\(value) forks"
-            }
+            .mapAt(\.forksCount.description)
             .asDriver(onErrorDriveWith: .never())
     }
     
@@ -187,10 +175,7 @@ extension Reactive where Base: RepositoryDetailViewController.Store {
         base.stateObservable.mapAt(\.repositoryData)
             .unwrap()
             .distinctUntilChanged()
-            .mapAt(\.openIssuesCount)
-            .map { value in
-                "\(value) open issues"
-            }
+            .mapAt(\.openIssuesCount.description)
             .asDriver(onErrorDriveWith: .never())
     }
     

--- a/iOSEngineerCodeCheck/UserInterface/RepositoryDetail/RepositoryDetailViewController.swift
+++ b/iOSEngineerCodeCheck/UserInterface/RepositoryDetail/RepositoryDetailViewController.swift
@@ -16,6 +16,7 @@ class RepositoryDetailViewController: UIViewController {
     typealias State = RepositoryDetailState
     typealias Store = RxStore<State>
     
+    @IBOutlet weak private var blurEffectBackground: BlurEffectView!
     @IBOutlet weak private var avatarImageView: UIImageView!
     
     @IBOutlet weak private var titleLabel: UILabel!
@@ -72,8 +73,9 @@ class RepositoryDetailViewController: UIViewController {
             .disposed(by: disposeBag)
         
         store.rx.avatarImage
-            .drive(onNext: { [weak self] value in
-                self?.avatarImageView.kf.setImage(with: value)
+            .drive(Binder(self) { me, value in
+                me.avatarImageView.kf.setImage(with: value)
+                me.blurEffectBackground.image.kf.setImage(with: value)
             })
             .disposed(by: disposeBag)
         

--- a/iOSEngineerCodeCheck/UserInterface/RepositoryDetail/RepositoryDetailViewController.swift
+++ b/iOSEngineerCodeCheck/UserInterface/RepositoryDetail/RepositoryDetailViewController.swift
@@ -20,6 +20,7 @@ class RepositoryDetailViewController: UIViewController {
     @IBOutlet weak private var avatarImageView: UIImageView!
     
     @IBOutlet weak private var titleLabel: UILabel!
+    @IBOutlet weak private var descriptionLabel: UILabel!
     
     @IBOutlet weak private var languageLabel: UILabel!
     
@@ -37,6 +38,8 @@ class RepositoryDetailViewController: UIViewController {
         let favoriteButton = UIBarButtonItem(image: .init(systemName: "heart"), style: .plain, target: self, action: nil)
         navigationItem.rightBarButtonItem = favoriteButton
         
+        titleLabel.sizeToFit()
+        
         bind()
         guard let repositoryData = store.state.repositoryData else {
             return
@@ -50,6 +53,10 @@ class RepositoryDetailViewController: UIViewController {
     private func bind() {
         store.rx.fullName
             .drive(titleLabel.rx.text)
+            .disposed(by: disposeBag)
+        
+        store.rx.descriptionText
+            .drive(descriptionLabel.rx.text)
             .disposed(by: disposeBag)
         
         store.rx.language
@@ -118,6 +125,14 @@ extension Reactive where Base: RepositoryDetailViewController.Store {
             .unwrap()
             .distinctUntilChanged()
             .mapAt(\.fullName)
+            .asDriver(onErrorDriveWith: .never())
+    }
+    
+    var descriptionText: Driver<String?> {
+        base.stateObservable.mapAt(\.repositoryData)
+            .unwrap()
+            .distinctUntilChanged()
+            .mapAt(\.description)
             .asDriver(onErrorDriveWith: .never())
     }
     

--- a/iOSEngineerCodeCheck/UserInterface/RepositoryList/RepositoryListViewController.swift
+++ b/iOSEngineerCodeCheck/UserInterface/RepositoryList/RepositoryListViewController.swift
@@ -35,7 +35,7 @@ class RepositoryListViewController: UITableViewController, UISearchBarDelegate {
         // Do any additional setup after loading the view.
         title = "検索画面"
         navigationController?.navigationBar.prefersLargeTitles = true
-        navigationItem.largeTitleDisplayMode = .always
+        navigationItem.largeTitleDisplayMode = .automatic
         searchBar.placeholder = "GitHubのリポジトリを検索できるよー"
         searchBar.delegate = self
         tableView.dataSource = nil


### PR DESCRIPTION
## 概要
SSIA

## issue
#7 

## 作業内容
- 詳細画面のNavigationBarをlargeTitleではないように変更
- CardView.swiftを作成してその上にavatarImageViewを配置するように修正
- avatar image、full name、languageを表示している部分の背景をavatar imageをぼかしたものにするためBlurEffectViewを実装して配置
    - 上にスクロールする時に背景が消えないよう制約を追加。その過程でstatusBarの高さを取得したいのでSceneDelegateにstatusBarの高さを取得するコード追加
- 各情報が一目でわかるようにアイコンを配置
- SE画面でも表示されるようにscrollViewの上にUIを配置
- リポジトリの説明文を表示するように修正
- リポジトリ情報部分をリストのようなデザインに修正
※iPhoneのポッドキャストを参考に作成

## UI

|| Before | After |
| ------------- | ------------- | ------------- |
|iPhone 13 Pro Max| <img src="https://user-images.githubusercontent.com/20432404/209629317-64784ef1-9f86-4581-8365-e0bedb225690.png" width=250 heigh=500>  | <img src="https://user-images.githubusercontent.com/20432404/209624579-f319215d-4aa2-40ff-a5df-4617ed1bcea1.png" width=250 heigh=500>  |
|iPhone SE| <img src="https://user-images.githubusercontent.com/20432404/209629323-53d31293-6420-40a1-9410-b813b184bf81.png" width=250 heigh=500>  | <img src="https://user-images.githubusercontent.com/20432404/209624605-598036e7-a9a3-4dd4-8ef8-5090b033d2c7.png" width=250 heigh=500> <img src="https://user-images.githubusercontent.com/20432404/209624611-ede19700-fa84-4ce0-b5c4-26d3b209d3c6.png" width=250 heigh=500> |