### PR TITLE
リポジトリ詳細画面のぼかし背景部分のデザインを修正

### DIFF
--- a/iOSEngineerCodeCheck/UIComponent/BlurEffectView/BlurEffectView.swift
+++ b/iOSEngineerCodeCheck/UIComponent/BlurEffectView/BlurEffectView.swift
@@ -28,6 +28,11 @@ class BlurEffectView: UIView {
         let nib = UINib(nibName: "BlurEffectView", bundle: nil)
         guard let view = nib.instantiate(withOwner: self, options: nil).first as? UIView else { return }
         addSubview(view)
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.topAnchor.constraint(equalTo: self.topAnchor, constant: 0).isActive = true
+        view.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: 0).isActive = true
+        view.rightAnchor.constraint(equalTo: self.rightAnchor, constant: 0).isActive = true
+        view.leftAnchor.constraint(equalTo: self.leftAnchor, constant: 0).isActive = true
         
         let blurEffect = UIBlurEffect(style: .systemMaterial)
         blurEffectView = UIVisualEffectView(effect: blurEffect)

--- a/iOSEngineerCodeCheck/UIComponent/BlurEffectView/BlurEffectView.xib
+++ b/iOSEngineerCodeCheck/UIComponent/BlurEffectView/BlurEffectView.xib
@@ -18,7 +18,7 @@
             <rect key="frame" x="0.0" y="0.0" width="414" height="303"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="u2a-Ut-LvT">
+                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="u2a-Ut-LvT">
                     <rect key="frame" x="0.0" y="0.0" width="414" height="212"/>
                 </imageView>
             </subviews>


### PR DESCRIPTION
## 概要
SSIA

## 作業内容
- どんな画像でもUIImageViewのサイズいっぱいに広がって欲しいのでぼかし背景部分の画像のcontentModeをcenterからscaleAspectFillに変更
- 背景色でグレーを指定しているViewの部分が正しく配置されないのでUINibから取得したviewにもautolayoutを指定

## UI
| Before | After |
| ------------- | ------------- |
| <img src="https://user-images.githubusercontent.com/20432404/209674846-b30dca76-cc2e-4db0-a526-a214d6ef65b1.png" width=250 heigh=500>  | <img src="https://user-images.githubusercontent.com/20432404/209674026-3814da6c-c95e-4641-8f6e-ff505d4622b2.png" width=250 heigh=500>  |
| <img src="https://user-images.githubusercontent.com/20432404/209675128-230c57de-f698-4e87-b8e7-0553703afb2b.png" width=250 heigh=500>  | <img src="https://user-images.githubusercontent.com/20432404/209675131-df66a962-33dc-41ff-a962-350ba41422d5.png" width=250 heigh=500>  |